### PR TITLE
Adjust the call paramters for the seekpath_structure_analysis function accordingly.

### DIFF
--- a/aiida_wannier90_workflows/workflows/bands.py
+++ b/aiida_wannier90_workflows/workflows/bands.py
@@ -230,7 +230,7 @@ class Wannier90BandsWorkChain(WorkChain):
             format(structure_formula)
         )
         result = seekpath_structure_analysis(
-            self.inputs.structure, seekpath_parameters
+            self.inputs.structure, **seekpath_parameters
         )
         self.ctx.current_structure = result['primitive_structure']
         self.ctx.explicit_kpoints_path = result['explicit_kpoints']


### PR DESCRIPTION
See https://github.com/aiidateam/aiida-wannier90-workflows/issues/3
and
https://github.com/aiidateam/aiida-quantumespresso/commit/ec24908162fe9c606bd6e491d6253f31e2436957

 `seekpath_structure_analysis`: expand parameter input into keywords
    
So, adjust the call method for the seekpath_structure_analysis function accordingly.
