### PR TITLE
Propagate changes in 'parameters' when auto_projections is off.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ ENV/
 .spyderproject
 .spyproject
 
+# VSCode project settings
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/aiida_wannier90_workflows/workflows/wannier.py
+++ b/aiida_wannier90_workflows/workflows/wannier.py
@@ -495,6 +495,8 @@ class Wannier90WorkChain(WorkChain):
                     'number of Wannier functions extracted from projections: '
                     + str(inputs.parameters['num_wann'])
                 )
+        else:
+            inputs.parameters = orm.Dict(dict=parameters)
 
         # get scf Fermi energy
         try:


### PR DESCRIPTION
When `auto_projections` is `False`, the changes to `parameters` were not being applied, because casting it to a `Dict` and assigning to `inputs['parameters']` happened only inside the `'auto_projections'=True` branch.

This is fixed by adding an else statement to that branch.

In principle it would be nicer to do the cast to `Dict` in one place, but that would need some more changes because `only_valence=True` needs to do the cast at the end, while `only_valence=False` needs to do it at the beginning.