### PR TITLE
Make 'parameters' input of 'pw2wannier90' optional.

### DIFF
--- a/aiida_wannier90_workflows/workflows/wannier.py
+++ b/aiida_wannier90_workflows/workflows/wannier.py
@@ -563,7 +563,12 @@ class Wannier90WorkChain(WorkChain):
 
         inputs['parent_folder'] = remote_folder
         inputs['nnkp_file'] = self.ctx.calc_wannier90_pp.outputs.nnkp_file
-        inputs.parameters = inputs.parameters.get_dict()
+        try:
+            inputs.parameters = inputs.parameters.get_dict()
+        except AttributeError:
+            inputs.parameters = {}
+        inputs.parameters.setdefault('inputpp', {})
+
         inputs.parameters['inputpp'].update({
             'write_mmn': True,
             'write_amn': True,


### PR DESCRIPTION
When the `pw2wannier90.parameters` are not set, the workchain excepts because `inputs.parameters` is accessed without a check.

In `aiida-quantumespresso`, the `parameters` are optional, which is why this error is not caught by the input validation.

This is fixed by catching the exception, and using an empty dictionary.

Passing an empty `Dict` is now also allowed, by setting an empty `parameters['inputpp']` dictionary if it does not exist.