### PR TITLE
Remove deprecated `validate_inputs_base`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires-python = ">=3.8"
 dependencies = [
     "aiida-core>=2.0,<3",
     "aiida-pseudo>=0.6",
-    "aiida-quantumespresso>=4.3",
+    "aiida-quantumespresso>=4.4",
     "aiida-wannier90>=2.1",
     "click>=8.0",
     "colorama"

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -8,7 +8,6 @@ from aiida.common.lang import type_check
 from aiida.engine.processes import ProcessBuilder, ToContext, WorkChain, if_
 from aiida.orm.nodes.data.base import to_aiida_type
 
-from aiida_quantumespresso.calculations.pw import PwCalculation
 from aiida_quantumespresso.common.types import ElectronicType, SpinType
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
@@ -99,14 +98,13 @@ class Wannier90WorkChain(
         spec.expose_inputs(
             PwBaseWorkChain,
             namespace="nscf",
-            exclude=("clean_workdir", "pw.structure"),
+            exclude=("clean_workdir", "pw.structure", "pw.parent_folder"),
             namespace_options={
                 "required": False,
                 "populate_defaults": False,
                 "help": "Inputs for the `PwBaseWorkChain` for the NSCF calculation.",
             },
         )
-        spec.inputs["nscf"]["pw"].validator = PwCalculation.validate_inputs_base
         spec.expose_inputs(
             ProjwfcBaseWorkChain,
             namespace="projwfc",


### PR DESCRIPTION
In https://github.com/aiidateam/aiida-quantumespresso/commit/a389629387b74805ffe2f4d6515ac05b8f62b4d5, the validation of the `parent_folder` was adapted to no longer rely on splitting up the validation of the top-level inputs in `validate_inputs` and `validate_inputs_base`. Instead, a wrapping work chain can just exclude the `parent_folder` when exposing the inputs of e.g. a `PwBaseWorkChain` whose `parent_folder` will be obtained at run-time.

Here we remove the line adapting the validator of the `PwCalculation` in the `nscf` namespace of the `Wannier90WorkChain` to `validate_inputs_base`, and exclude `pw.parent_folder` from this namespace instead.