### PR TITLE
Bug fix: wrong output bands

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -734,9 +734,6 @@ class Wannier90OptimizeWorkChain(Wannier90BandsWorkChain):
                     namespace="wannier90_plot",
                 )
             )
-            if "interpolated_bands" in self.outputs["wannier90_plot"]:
-                w90_bands = self.outputs["wannier90_plot"]["interpolated_bands"]
-                self.out("band_structure", w90_bands)
 
         if "optimize_reference_bands" in self.inputs:
             if self.has_run_wannier90_optimize():
@@ -744,6 +741,11 @@ class Wannier90OptimizeWorkChain(Wannier90BandsWorkChain):
             else:
                 # Even if I haven't run optimization, I still output bands distance if reference bands is present
                 optimal_workchain = self.ctx.workchain_wannier90
+
+            if "interpolated_bands" in optimal_workchain.outputs:
+                # Override the `band_strucure` from W90BandsWorkChain
+                w90_optimal_bands = optimal_workchain.outputs["interpolated_bands"]
+                self.out("band_structure", w90_optimal_bands)
             bandsdist = self._get_bands_distance(optimal_workchain)
             bandsdist = orm.Float(bandsdist)
             bandsdist.store()


### PR DESCRIPTION
- Output the `band_structure` from `wannier90_optimal` correctly:
    In #40, the `bands_plot` has been separated from the `wannier_plot` and integrated into each `wannier90_optimize_iteration`.
    Because `wannier_plot` cannot be found, the original `results` logic in `Wannier90OptimizeWorkChain` will directly output the `interpolated_bands` from `wannier90` as the final output bands rather than from the `wannier90_optimal`.