### PR TITLE
Fix override errors.

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -273,6 +273,8 @@ class Wannier90OptimizeWorkChain(Wannier90BandsWorkChain):
         :return: [description]
         :rtype: ProcessBuilder
         """
+        from copy import deepcopy
+
         from aiida_wannier90_workflows.utils.workflows.bands import (
             has_overlapping_semicore,
         )
@@ -290,7 +292,7 @@ class Wannier90OptimizeWorkChain(Wannier90BandsWorkChain):
         )
 
         parent_builder = Wannier90BandsWorkChain.get_builder_from_protocol(
-            codes, structure, overrides=inputs, **kwargs
+            codes, structure, overrides=deepcopy(inputs), **kwargs
         )
 
         if reference_bands is not None:


### PR DESCRIPTION
When set `override = {"wannier90":{"meta_parameters":{SOMETHING}}}`, the `inputs` will automatically set to:
`{"wannier90":{"meta_parameters":{SOMETHING, "exclude_semicore": True}}}`. This will make the check of `overlap_semicores` invalid.

Use `deepcopy` to temp fix it.