### PR TITLE
Add support for PDWF with external projectors

### DIFF
--- a/src/aiida_wannier90_workflows/common/types.py
+++ b/src/aiida_wannier90_workflows/common/types.py
@@ -19,8 +19,8 @@ class WannierProjectionType(enum.Enum):
     # Atomic pseudo wavefunctions contained in the QE pseudopotentials
     ATOMIC_PROJECTORS_QE = "atomic_projectors_qe"
 
-    # Atomic orbitals from OpenMX basis set
-    ATOMIC_PROJECTORS_OPENMX = "atomic_projectors_openmx"
+    # Atomic orbitals from external source
+    ATOMIC_PROJECTORS_EXTERNAL = "atomic_projectors_external"
 
 
 class WannierDisentanglementType(enum.Enum):

--- a/src/aiida_wannier90_workflows/utils/workflows/builder/projections.py
+++ b/src/aiida_wannier90_workflows/utils/workflows/builder/projections.py
@@ -75,7 +75,7 @@ def guess_wannier_projection_types(
                 )
         elif projection_type in [
             WannierProjectionType.ATOMIC_PROJECTORS_QE,
-            WannierProjectionType.ATOMIC_PROJECTORS_OPENMX,
+            WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL,
         ]:
             if disentanglement_type is None:
                 disentanglement_type = WannierDisentanglementType.SMV

--- a/src/aiida_wannier90_workflows/workflows/base/pw2wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/pw2wannier90.py
@@ -175,12 +175,12 @@ class Pw2wannier90BaseWorkChain(ProtocolMixin, QeBaseRestartWorkChain):
                 # scdm_mu, scdm_sigma will be set at runtime
         elif projection_type in [
             WannierProjectionType.ATOMIC_PROJECTORS_QE,
-            WannierProjectionType.ATOMIC_PROJECTORS_OPENMX,
+            WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL,
         ]:
             parameters["atom_proj"] = True
             if exclude_projectors is not None and len(exclude_projectors) > 0:
                 parameters["atom_proj_exclude"] = list(exclude_projectors)
-            if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_OPENMX:
+            if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL:
                 parameters["atom_proj_ext"] = True
                 if external_projectors_path is None:
                     raise ValueError(

--- a/src/aiida_wannier90_workflows/workflows/base/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/wannier90.py
@@ -330,11 +330,13 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
                 factor=meta_parameters["num_bands_factor"],
                 only_valence=only_valence,
                 spin_polarized=spin_polarized,
+                spin_non_collinear=spin_non_collinear,
                 spin_orbit_coupling=spin_orbit_coupling,
             )
             num_projs = get_number_of_projections_ext(
                 structure=structure,
                 external_projectors=external_projectors,
+                spin_non_collinear=spin_non_collinear,
                 spin_orbit_coupling=spin_orbit_coupling,
             )
         else:
@@ -344,11 +346,13 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
                 factor=meta_parameters["num_bands_factor"],
                 only_valence=only_valence,
                 spin_polarized=spin_polarized,
+                spin_non_collinear=spin_non_collinear,
                 spin_orbit_coupling=spin_orbit_coupling,
             )
             num_projs = get_number_of_projections(
                 structure=structure,
                 pseudos=pseudos,
+                spin_non_collinear=spin_non_collinear,
                 spin_orbit_coupling=spin_orbit_coupling,
             )
 

--- a/src/aiida_wannier90_workflows/workflows/base/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/wannier90.py
@@ -318,7 +318,7 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             pseudo_family = meta_parameters["pseudo_family"]
         pseudos, _, _ = get_pseudo_and_cutoff(pseudo_family, structure)
 
-        if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_OPENMX:
+        if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL:
             if external_projectors is None:
                 raise ValueError(
                     f"Must specify `external_projectors` when using {projection_type}"
@@ -359,7 +359,7 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         if meta_parameters["exclude_semicore"]:
             pseudo_orbitals = get_pseudo_orbitals(pseudos)
-            if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_OPENMX:
+            if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL:
                 semicore_list = get_semicore_list_ext(
                     structure, external_projectors, pseudo_orbitals, spin_non_collinear
                 )
@@ -388,7 +388,7 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         if projection_type in [
             WannierProjectionType.SCDM,
             WannierProjectionType.ATOMIC_PROJECTORS_QE,
-            WannierProjectionType.ATOMIC_PROJECTORS_OPENMX,
+            WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL,
         ]:
             parameters["auto_projections"] = True
         elif projection_type == WannierProjectionType.ANALYTIC:

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -349,7 +349,7 @@ class Wannier90WorkChain(
             frozen_type=frozen_type,
         )
 
-        if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_OPENMX:
+        if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL:
             if external_projectors_path is None:
                 raise ValueError(
                     f"Must specify `external_projectors_path` when using {projection_type}"
@@ -520,7 +520,7 @@ class Wannier90WorkChain(
         exclude_projectors = None
         if exclude_semicore:
             pseudo_orbitals = get_pseudo_orbitals(builder["scf"]["pw"]["pseudos"])
-            if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_OPENMX:
+            if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL:
                 exclude_projectors = get_semicore_list_ext(
                     structure, external_projectors, pseudo_orbitals, spin_non_collinear
                 )

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -995,11 +995,22 @@ class Wannier90WorkChain(
         check_num_projs = True
         if self.should_run_scf():
             pseudos = self.inputs["scf"]["pw"]["pseudos"]
+            spin_orbit_coupling = (
+                self.inputs["scf"]["pw"]["parameters"]
+                .get_dict()["SYSTEM"]
+                .get("SYSTEM", False)
+            )
         elif self.should_run_nscf():
             pseudos = self.inputs["nscf"]["pw"]["pseudos"]
+            spin_orbit_coupling = (
+                self.inputs["nscf"]["pw"]["parameters"]
+                .get_dict()["SYSTEM"]
+                .get("SYSTEM", False)
+            )
         else:
             check_num_projs = False
-            pseudos = None  # to avoid pylint errors
+            pseudos = None
+            spin_orbit_coupling = None
         if check_num_projs:
             args = {
                 "structure": self.ctx.current_structure,
@@ -1014,9 +1025,11 @@ class Wannier90WorkChain(
                 params = self.ctx.workchain_wannier90.inputs["wannier90"][
                     "parameters"
                 ].get_dict()
-                spin_orbit_coupling = params.get("spinors", False)
+                spin_non_collinear = params.get("spinors", False)
                 number_of_projections = get_number_of_projections(
-                    **args, spin_orbit_coupling=spin_orbit_coupling
+                    **args,
+                    spin_non_collinear=spin_non_collinear,
+                    spin_orbit_coupling=spin_orbit_coupling,
                 )
                 if number_of_projections != num_proj:
                     self.report(

--- a/tests/workflows/protocols/test_bands.py
+++ b/tests/workflows/protocols/test_bands.py
@@ -135,7 +135,7 @@ def test_projection_type(generate_builder_inputs):
     # with pytest.raises(NotImplementedError):
     #     for projection_type in [
     #         WannierProjectionType.ANALYTIC, WannierProjectionType.RANDOM,
-    #         WannierProjectionType.ATOMIC_PROJECTORS_OPENMX
+    #         WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL
     #     ]:
     #         builder = Wannier90BandsWorkChain.get_builder_from_protocol(
     #             **generate_builder_inputs(), projection_type=projection_type, print_summary=False

--- a/tests/workflows/protocols/test_open_grid.py
+++ b/tests/workflows/protocols/test_open_grid.py
@@ -115,7 +115,7 @@ def test_projection_type(generate_builder_inputs):
     # with pytest.raises(NotImplementedError):
     #     for projection_type in [
     #         WannierProjectionType.ANALYTIC, WannierProjectionType.RANDOM,
-    #         WannierProjectionType.ATOMIC_PROJECTORS_OPENMX
+    #         WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL
     #     ]:
     #         builder = Wannier90OpenGridWorkChain.get_builder_from_protocol(
     #             **generate_builder_inputs(), projection_type=projection_type

--- a/tests/workflows/protocols/test_optimize.py
+++ b/tests/workflows/protocols/test_optimize.py
@@ -122,7 +122,7 @@ def test_projection_type(generate_builder_inputs):
     # with pytest.raises(NotImplementedError):
     #     for projection_type in [
     #         WannierProjectionType.ANALYTIC, WannierProjectionType.RANDOM,
-    #         WannierProjectionType.ATOMIC_PROJECTORS_OPENMX
+    #         WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL
     #     ]:
     #         builder = Wannier90OptimizeWorkChain.get_builder_from_protocol(
     #             **generate_builder_inputs(), projection_type=projection_type, print_summary=False

--- a/tests/workflows/protocols/test_wannier90.py
+++ b/tests/workflows/protocols/test_wannier90.py
@@ -135,7 +135,7 @@ def test_projection_type(generate_builder_inputs):
     # with pytest.raises(NotImplementedError):
     #     for projection_type in [
     #         WannierProjectionType.ANALYTIC, WannierProjectionType.RANDOM,
-    #         WannierProjectionType.ATOMIC_PROJECTORS_OPENMX
+    #         WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL
     #     ]:
     #         builder = Wannier90WorkChain.get_builder_from_protocol(
     #             **generate_builder_inputs(), projection_type=projection_type, print_summary=False


### PR DESCRIPTION
The `atom_proj_ext` in `pw2wannier90` is not only applicable to projectors in the `openMX` format, any reasonable projector that meets the file format rules can be used for `PDWF`. Therefore, I have renamed `WannierProjectionType`.`ATOMIC_PROJECTORS_OPENMX` to `ATOMIC_PROJECTORS_EXTERNAL` and added some functions. Now, we only need to provide additional `external_projectors`, and the workflow will automatically compute number of projectors and semicore lists, and do the calculation automatically.

Format of `external_projectors`: A dict of projectors for elements
For non-spin-orbit-coupling projectors:
`"F": [{"label": "2S", "l": 0}, {"label": "2P", "l": 1}],`
For spin-orbit-coupling projectors:
`"F": [{"label": "2S", "l": 0, "j": 0.5}, {"label": "2P", "l": 1, "j": 0.5}, {"label": "2P", "l": 1, "j": 1.5}],`