### PR TITLE
Simplify `get_builder_from_protocol` in `ProjwfcBandsWorkChain`

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/projwfcbands.py
+++ b/src/aiida_wannier90_workflows/workflows/projwfcbands.py
@@ -118,15 +118,17 @@ class ProjwfcBandsWorkChain(PwBandsWorkChain):
         # Prepare workchain builder
         builder = cls.get_builder()
 
-        projwfc_overrides = None
-        if overrides:
-            projwfc_overrides = overrides.pop("projwfc", None)
+        protocol_inputs = cls.get_protocol_inputs(
+            protocol=protocol, overrides=overrides
+        )
+
+        projwfc_overrides = protocol_inputs.pop("projwfc", None)
 
         pwbands_builder = PwBandsWorkChain.get_builder_from_protocol(
             code=pw_code,
             structure=structure,
             protocol=protocol,
-            overrides=overrides,
+            overrides=protocol_inputs,
             **kwargs,
         )
 


### PR DESCRIPTION
Hi @qiaojunfeng, thanks for this nice work!

We (well, mainly @AndresOrtegaGuerrero) are working on integrating the `ProjwfcBandsWorkChain` into AiiDAlab. Andres realized that it's not possible to provide Python datatypes in the `overrides` when using the `get_builder_from_protocol` method (I could confirm this behavior). One example is passing a `float` for `kpoints_distance`. However, this is possible in the AiiDA-QE plugin.

The problem occurs in the following part:
https://github.com/aiidateam/aiida-wannier90-workflows/blob/d6794cf44a3ab3d6ac11fcfff06a57603e824480/src/aiida_wannier90_workflows/workflows/projwfcbands.py#L157

The `PwBandsWorkChain.get_builder_from_protocol` transformed the relevant inputs into AiiDA datatypes, but the aforementioned call of `recursive_merge_container` merges the plain Python datatypes from the `protcol_inputs` again.

I fixed this behavior in this PR and generally tried to simplify the `get_builder_from_protocol`. As the `ProjwfcBandsWorkChain` is a child class of the `PwBandsWorkChain`, the majority of the preparation is already done  in `PwBandsWorkChain.get_builder_from_protocol`.
For example, I'm not sure if the following is really needed:
https://github.com/aiidateam/aiida-wannier90-workflows/blob/d6794cf44a3ab3d6ac11fcfff06a57603e824480/src/aiida_wannier90_workflows/workflows/projwfcbands.py#L122-L124

The protocol inputs are anyway passed to the `get_builder_from_protocol` methods of the sub-workchains and the `ProjwfcBandsWorkChain` doesn't have any additional inputs that are specific to this `WorkChain`.

I tested the changes and the results seem to be identical (at least within my tests). In case I removed parts that are necessary for the intended functionality because I misunderstood them, please let me know. I'm happy to revert certain changes/to adapt them.