### PR TITLE
Add inputs to compute Fermi surface

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -99,6 +99,7 @@ class Wannier90OptimizeWorkChain(Wannier90BandsWorkChain):
         "write_hkmn",
         "write_hvmn",
         "write_hdmn",
+        "fermi_surface_plot",
     )
 
     @classmethod

--- a/src/aiida_wannier90_workflows/workflows/protocols/overrides/wannier90.yaml
+++ b/src/aiida_wannier90_workflows/workflows/protocols/overrides/wannier90.yaml
@@ -30,6 +30,14 @@ retrieve_matrices:
                     - '*.amn'
                     - '*.mmn'
                     - '*.spn'
+compute_fermi_surface:
+    wannier90:
+        wannier90:
+            parameters:
+                fermi_surface_plot: True
+            settings:
+                additional_retrieve_list:
+                    - '*.bxsf'
 spin_noncollinear:
     scf:
         pw:


### PR DESCRIPTION
 * Add `compute_fermi_surface` and `fermi_surface_kpoint_distance` flags to `get_builder_from_protocol` function of Wannier90WorkChain

Allow specifying k-point distance for Fermi surface calculation
* Handle `fermi_surface_kpoint_distance` keyword in `get_builder_from_protocol` of Wannier90WorkChain

Allow plotting Fermi surface in the end of Wannier90OptimizeWorkChain
* Add `fermi_surface_plot` to `_WANNIER90_PLOT_INPUTS`