### PR TITLE
Fix NameError when aiida-hyperqueue not installed

### DIFF
--- a/src/aiida_wannier90_workflows/utils/workflows/builder/setter.py
+++ b/src/aiida_wannier90_workflows/utils/workflows/builder/setter.py
@@ -124,7 +124,7 @@ def set_parallelization(
         pruned_builder = builder._inputs(prune=True)  # pylint: disable=protected-access
 
     run_hyperqueue = False
-    if code is not None:
+    if code is not None and aiida_hq_installed:
         run_hyperqueue = isinstance(code.computer.get_scheduler(), HyperQueueScheduler)
 
     if run_hyperqueue:


### PR DESCRIPTION
After updating the package, I experienced `NameError: name 'HyperQueueScheduler' is not defined` when using the `set_parallelization` function.
Fix: check if the plugin is installed before checking if the scheduler is "HyperQueue"

However, this might lead to a failure if the `computer` has a HyperQueue scheduler, but the `aiida-hyperqueue` plugin is not installed (don't know if this is a likely scenario)