### PR TITLE
Bug fix for `Pw2wannier90BaseWorkChain`

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/base/pw2wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/pw2wannier90.py
@@ -188,7 +188,7 @@ class Pw2wannier90BaseWorkChain(ProtocolMixin, QeBaseRestartWorkChain):
                     raise ValueError(
                         f"Must specify `external_projectors_path` when using {projection_type}"
                     )
-                parameters["atom_proj_dir"] = "external_projectors/"
+                parameters["atom_proj_dir"] = external_projectors_path
                 if (
                     external_projectors_froz is not None
                     and len(external_projectors_froz) > 0


### PR DESCRIPTION
 * When using external projectors, `parameters["atom_proj_dir"]` should be set to the `external_projectors_path` input
Without this, I was getting an error from pw2wannier90.x 