### PR TITLE
Fix bugs caused by PR#70

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -697,9 +697,19 @@ class Wannier90WorkChain(
                 self.ctx.current_folder = self.inputs["pw2wannier90"]["pw2wannier90"][
                     "parent_folder"
                 ]
-            self.ctx.spin_collinear = (
-                self.inputs["nscf"]["pw"]["parameters"]["SYSTEM"].get("nspin", 1) == 2
-            )
+            # determine if we should use collinear spin.
+            if self.should_run_nscf():
+                self.ctx.spin_collinear = (
+                    self.inputs["nscf"]["pw"]["parameters"]["SYSTEM"].get("nspin", 1)
+                    == 2
+                )
+            else:
+                self.ctx.spin_collinear = False
+                self.report(
+                    "Warning: "
+                    "currently can not determine whether the workflow uses collinear spin, "
+                    "because it skips scf and nscf steps."
+                )
         else:
             self.ctx.spin_collinear = (
                 self.inputs["scf"]["pw"]["parameters"]["SYSTEM"].get("nspin", 1) == 2


### PR DESCRIPTION
Fix bugs
#71 : bug was triggered by running `check_num_proj` without executing `projwfc.x`(no `workchain_projwfc`). So I revise the logic and optimize the code structure of `sanity_check`.
I ran few check and it seems work well for `WannierProjectionType.ATOMIC_PROJECTORS_QE`.
@npaulish can check if it works for you.
#72 : because we cannot determine spin state if `scf` and `nscf` are skipped, so I could only use a temporary default setting of the spin state to not collinear (different from non-collinear). Further efforts are required to establish a proper determination mechanism under such conditions (currently spin_type do not pass to builder, maybe should add it to the builder?).