### PR TITLE
Support  SSSP v1.3

### DIFF
--- a/dev/semicore/pseudos.py
+++ b/dev/semicore/pseudos.py
@@ -19,7 +19,11 @@ load_profile()
 
 
 def generate_semicore_dict(pseudo: UpfData, semicore_threshold=-1.8) -> dict:
-    """Generate the semicore dict for a given pseudo potential."""
+    """Generate the semicore dict for a given pseudo potential.
+
+    Fails if there is no `pseudo_energy` in the UPF file.
+    In this case, use the `generate_semicore_dict_from_orbitals` function instead.
+    """
     upf = UPFDict.from_str(pseudo.get_content())
     filename = pseudo.filename
     md5_hash = hashlib.md5(pseudo.get_content().encode()).hexdigest()
@@ -55,6 +59,7 @@ def generate_semicore_dict_from_orbitals(pseudo: UpfData) -> dict:
     """Generate the semicore dict based on the orbitals in the pseudo.
 
     Take into account the element's position in the periodic table.
+    More robust way to determine semicores, works also for UPF version 1.
     """
     from ase.data import atomic_numbers
 

--- a/dev/semicore/pseudos.py
+++ b/dev/semicore/pseudos.py
@@ -2,7 +2,7 @@
 """Generate the semicore JSON for a given pseudo family."""
 from collections import OrderedDict
 import hashlib
-from importlib.resources import path
+from importlib.resources import files
 import json
 
 from aiida_pseudo.data.pseudo.upf import UpfData
@@ -51,7 +51,75 @@ def generate_semicore_dict(pseudo: UpfData, semicore_threshold=-1.8) -> dict:
     }
 
 
-def cli(pseudo_family: str, semicore_threshold: float = -1.8):
+def generate_semicore_dict_from_orbitals(pseudo: UpfData) -> dict:
+    """Generate the semicore dict based on the orbitals in the pseudo.
+
+    Take into account the element's position in the periodic table.
+    """
+    from ase.data import atomic_numbers
+
+    # P-block elements
+    pblock = (
+        list(range(31, 37))
+        + list(range(49, 55))
+        + list(range(81, 87))
+        + list(range(113, 119))
+    )
+
+    upf = UPFDict.from_str(pseudo.get_content())
+    filename = pseudo.filename
+    md5_hash = hashlib.md5(pseudo.get_content().encode()).hexdigest()
+    znum = atomic_numbers[upf["header"]["element"].strip()]
+    pswfcs_list = []
+    for wfc in upf["pswfc"]["chi"]:
+        # Calculate the rank based on the atomic number (Z) and orbital type
+        # for S and P orbitals of elements in P-block we add 1 to the rank,
+        # for D and F orbitals we add 1 and 2 respectively (l-1)
+        rank = int(wfc["label"][0])  # Extract the main quantum number
+        l = int(wfc["l"])
+        if znum in pblock and l in (0, 1):
+            rank += 1
+        elif l > 1:
+            rank += l - 1
+
+        pswfcs_list.append(
+            {
+                "label": wfc["label"],
+                "rank": rank,
+            }
+        )
+    return {
+        upf["header"]["element"].strip(): {
+            "filename": filename,
+            "md5": md5_hash,
+            "pswfcs": [wfc["label"] for wfc in pswfcs_list],
+            "semicores": [
+                wfc["label"]
+                for wfc in pswfcs_list
+                if wfc["rank"] < max(wfc["rank"] for wfc in pswfcs_list)
+            ],
+        }
+    }
+
+
+def generate_semicore_dict_auto(
+    pseudo: UpfData, method: str = "energy_threshold", semicore_threshold: float = -1.8
+) -> dict:
+    """Generate the semicore dict for a given pseudo potential using the specified method."""
+    if method == "energy_threshold":
+        return generate_semicore_dict(pseudo, semicore_threshold)
+    if method == "orbitals":
+        return generate_semicore_dict_from_orbitals(pseudo)
+    raise ValueError(
+        f"Unknown method: {method}\nAvailable methods: 'energy_threshold', 'orbitals'."
+    )
+
+
+def cli(
+    pseudo_family: str,
+    method: str = "energy_threshold",
+    semicore_threshold: float = -1.8,
+):
     """Generate the semicore JSON for a given pseudo family."""
     pseudo_group = orm.load_group(pseudo_family)
 
@@ -61,14 +129,17 @@ def cli(pseudo_family: str, semicore_threshold: float = -1.8):
         pseudo_group.pseudos.values(),
         description=f"Generating semicore dict for {pseudo_family}",
     ):
-        semicore_dict.update(generate_semicore_dict(pseudo, semicore_threshold))
+        semicore_dict.update(
+            generate_semicore_dict_auto(pseudo, method, semicore_threshold)
+        )
 
-    with path(semicore, f"{pseudo_family.replace('/', '_')}.json") as semicore_path:
-        with semicore_path.open("w", encoding="utf8") as handle:
-            json.dump(OrderedDict(sorted(semicore_dict.items())), handle, indent=4)
+    semicore_path = files(semicore).joinpath(f"{pseudo_family.replace('/', '_')}.json")
+    with open(semicore_path, "w", encoding="utf8") as handle:
+        json.dump(OrderedDict(sorted(semicore_dict.items())), handle, indent=4)
+        handle.write("\n")
 
-        print("[bold green]Success:[/] the semicore JSON has been generated at:\n")
-        print(f"  {semicore_path.absolute()}\n")
+    print("[bold green]Success:[/] the semicore JSON has been generated at:\n")
+    print(f"  {semicore_path.absolute()}\n")
 
 
 if __name__ == "__main__":

--- a/examples/example_07.py
+++ b/examples/example_07.py
@@ -121,7 +121,7 @@ def cli(
     """Run a ``Wannier90BandsWorkChain`` with external projectors.
 
     FILENAME: a crystal structure file, e.g., ``input_files/GaAs.xsf``.
-    PSEUDO_FAMILY: label of pseudo family, e.g., ``SSSP/1.1/PBE/efficiency``.
+    PSEUDO_FAMILY: label of pseudo family, e.g., ``SSSP/1.3/PBEsol/efficiency``.
     EXTERNAL_PROJECTORS_PATH: the path to the directory on computing node which includes the external projectors.
     e.g., ``input_files/external_projectors/``
     """

--- a/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
+++ b/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
@@ -53,6 +53,8 @@ def get_pseudo_orbitals(pseudos: ty.Mapping[str, PseudoPotentialData]) -> dict:
     """Get the pseudo wave functions contained in the pseudo potential.
 
     Currently only support the following pseudopotentials installed by `aiida-pseudo`:
+        * SSSP/1.3/PBE/efficiency
+        * SSSP/1.3/PBEsol/efficiency
         * SSSP/1.1/PBE/efficiency
         * SSSP/1.1/PBEsol/efficiency
         * PseudoDojo/0.4/LDA/SR/standard/upf
@@ -69,6 +71,8 @@ def get_pseudo_orbitals(pseudos: ty.Mapping[str, PseudoPotentialData]) -> dict:
     from .data import load_pseudo_metadata
 
     pseudo_data = []
+    pseudo_data.append(load_pseudo_metadata("semicore/SSSP_1.3_PBE_efficiency.json"))
+    pseudo_data.append(load_pseudo_metadata("semicore/SSSP_1.3_PBEsol_efficiency.json"))
     pseudo_data.append(load_pseudo_metadata("semicore/SSSP_1.1_PBEsol_efficiency.json"))
     pseudo_data.append(load_pseudo_metadata("semicore/SSSP_1.1_PBE_efficiency.json"))
     pseudo_data.append(

--- a/src/aiida_wannier90_workflows/utils/pseudo/data/__init__.py
+++ b/src/aiida_wannier90_workflows/utils/pseudo/data/__init__.py
@@ -37,6 +37,9 @@ class PSHandler(xml.sax.ContentHandler):
     This script can generate cutoff energy/rho, pswfcs and semicores for
     FULLY RELATIVISTIC pseudopotentials (rel-*).
     Use SSSP or Pesudo-dojo for scalar/non relativistic pseudos.
+    Warning: this script does not work for UPF version 1!
+    For version 1, use the `generate_semicore_dict_from_orbitals` function in
+    `aiida_wannier90_workflows/dev/semicore/pseudos.py` instead.
     """
 
     def __init__(self) -> None:
@@ -104,6 +107,10 @@ class PSHandler(xml.sax.ContentHandler):
                     ll = 1
                 if orbtype == "F":
                     ll = 2
+                else:
+                    raise ValueError(
+                        f"Unknown orbital type: {orbtype} in {orb} for element {self.znum}"
+                    )
                 self.pswfcs_shell.append(nn + ll)
 
     def endElement(self, name):

--- a/src/aiida_wannier90_workflows/utils/pseudo/data/semicore/SSSP_1.3_PBE_efficiency.json
+++ b/src/aiida_wannier90_workflows/utils/pseudo/data/semicore/SSSP_1.3_PBE_efficiency.json
@@ -1,0 +1,1431 @@
+{
+    "Ac": {
+        "filename": "Ac.us.z_11.ld1.psl.v1.0.0-high.upf",
+        "md5": "3a78bb30464666358a3ec0edb47f6656",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "7P",
+            "6D"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ag": {
+        "filename": "Ag_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "94f47bd0669c641108e45594df92fabc",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Al": {
+        "filename": "Al.pbe-n-kjpaw_psl.1.0.0.UPF",
+        "md5": "cfc449ca30b5f3223ec38ddd88ac046d",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Am": {
+        "filename": "Am.paw.z_17.ld1.uni-marburg.v0.upf",
+        "md5": "b90604daea46e7f2635bfe47e71ce977",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ar": {
+        "filename": "Ar_ONCV_PBE-1.1.oncvpsp.upf",
+        "md5": "46d28409cdd246843f76b7675277a949",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "As": {
+        "filename": "As.pbe-n-rrkjus_psl.0.2.UPF",
+        "md5": "767315de957beeeb34f87d97bf945c8f",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "At": {
+        "filename": "At.us.z_17.ld1.psl.v1.0.0-high.upf",
+        "md5": "171e941146fbb8d42c50c0ba61055d18",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Au": {
+        "filename": "Au_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "d14007822ba0e19f0206237467fc06c2",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "6S",
+            "5D"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "B": {
+        "filename": "b_pbe_v1.4.uspp.F.UPF",
+        "md5": "cc6de2960df11db49a60e589f9ebb39b",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Ba": {
+        "filename": "Ba.pbe-spn-kjpaw_psl.1.0.0.UPF",
+        "md5": "c432291d3e53af55f19d5e8866385beb",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Be": {
+        "filename": "be_pbe_v1.4.uspp.F.UPF",
+        "md5": "5ecff1440924c7c98ad504bef30f5264",
+        "pswfcs": [
+            "1S",
+            "2S",
+            "2P"
+        ],
+        "semicores": [
+            "1S"
+        ]
+    },
+    "Bi": {
+        "filename": "Bi_pbe_v1.uspp.F.UPF",
+        "md5": "cceb9f28ec65b6d7ff33140f5b0b1758",
+        "pswfcs": [
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Bk": {
+        "filename": "Bk.paw.z_19.ld1.uni-marburg.v0.upf",
+        "md5": "34a5c1d9790ca2603c79955cdb099600",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Br": {
+        "filename": "br_pbe_v1.4.uspp.F.UPF",
+        "md5": "d3ffb7b29f6225aa16fe06858fb2a80b",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "C": {
+        "filename": "C.pbe-n-kjpaw_psl.1.0.0.UPF",
+        "md5": "5d2aebdfa2cae82b50a7e79e9516da0f",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Ca": {
+        "filename": "Ca_pbe_v1.uspp.F.UPF",
+        "md5": "403a4c14b9e4d4dfdc3024c9a3812218",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Cd": {
+        "filename": "Cd.pbe-dn-rrkjus_psl.0.3.1.UPF",
+        "md5": "558e9f355611b531a870a69ef6ace9e2",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "4D"
+        ],
+        "semicores": []
+    },
+    "Ce": {
+        "filename": "Ce.paw.z_12.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "2241420ff980c77e0c917a2dc8a7e08e",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Cf": {
+        "filename": "Cf.paw.z_20.ld1.uni-marburg.v0.upf",
+        "md5": "0e4adf7627c2d1305f26dd63271f2b94",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Cl": {
+        "filename": "cl_pbe_v1.4.uspp.F.UPF",
+        "md5": "fc6f6913ecf08c9257cb748ef0700058",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Cm": {
+        "filename": "Cm.paw.z_18.ld1.uni-marburg.v0.upf",
+        "md5": "fa6219561ad2ecb899c96af402755927",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Co": {
+        "filename": "Co_pbe_v1.2.uspp.F.UPF",
+        "md5": "5f91765df6ddd3222702df6e7b74a16d",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Cr": {
+        "filename": "cr_pbe_v1.5.uspp.F.UPF",
+        "md5": "0d52af634a40206e4dee301ad30da4bf",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Cs": {
+        "filename": "Cs_pbe_v1.uspp.F.UPF",
+        "md5": "3476d69cb178dfad3ffaa59df4e07ca4",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Cu": {
+        "filename": "Cu.paw.z_11.ld1.psl.v1.0.0-low.upf",
+        "md5": "619f40885d92a09a85a8b37550532d0c",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "3D"
+        ],
+        "semicores": []
+    },
+    "Dy": {
+        "filename": "Dy.paw.z_20.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "fad4f994dc38884d1fc17fd7bf5e13bf",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Er": {
+        "filename": "Er.paw.z_22.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "5ba6a5c626b1678e031aafe1da34e245",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Es": {
+        "filename": "Es.paw.z_21.ld1.uni-marburg.v0.upf",
+        "md5": "4bc7a67aee4e34db40c77f63d9e88986",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Eu": {
+        "filename": "Eu.paw.z_17.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "52b6e423bc4e840b6e0dc4248fa51623",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "F": {
+        "filename": "f_pbe_v1.4.uspp.F.UPF",
+        "md5": "4c38b6a325caf53ec0e86aed9459de46",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Fe": {
+        "filename": "Fe.pbe-spn-kjpaw_psl.0.2.1.UPF",
+        "md5": "e86618425769142926afa95317d90200",
+        "pswfcs": [
+            "3S",
+            "4S",
+            "3P",
+            "4P",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Fm": {
+        "filename": "Fm.paw.z_22.ld1.uni-marburg.v0.upf",
+        "md5": "2a5ec34d2abb196d3027bbefca4b5922",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Fr": {
+        "filename": "Fr.paw.z_19.ld1.psl.v1.0.0-high.upf",
+        "md5": "4e1baa83397213ef351c329de67c4222",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "6S",
+            "6P",
+            "5D"
+        ]
+    },
+    "Ga": {
+        "filename": "Ga.pbe-dn-kjpaw_psl.1.0.0.UPF",
+        "md5": "a27b4342b1af7e5f338de752e9ed7044",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "3D"
+        ],
+        "semicores": [
+            "3D"
+        ]
+    },
+    "Gd": {
+        "filename": "Gd.paw.z_18.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "a44f32af2ba180e1a67c5cef9ff7f39b",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Ge": {
+        "filename": "ge_pbe_v1.4.uspp.F.UPF",
+        "md5": "9c9eaa91e581c3f09632fb3098b2c6b2",
+        "pswfcs": [
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3D"
+        ]
+    },
+    "H": {
+        "filename": "H.pbe-rrkjus_psl.1.0.0.UPF",
+        "md5": "f52b6d4d1c606e5624b1dc7b2218f220",
+        "pswfcs": [
+            "1S"
+        ],
+        "semicores": []
+    },
+    "He": {
+        "filename": "He_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "e7160162b946020f132a727efeb32d00",
+        "pswfcs": [
+            "1S"
+        ],
+        "semicores": []
+    },
+    "Hf": {
+        "filename": "Hf-sp.oncvpsp.upf",
+        "md5": "417ed15784afe83d2e06dacf143de3f8",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Hg": {
+        "filename": "Hg_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "dd5a8773074bfcf4280086d4d95875c4",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "6S",
+            "5D"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Ho": {
+        "filename": "Ho.paw.z_21.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "f900adcc49abc9ab8113872cdbacec3e",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "I": {
+        "filename": "I.pbe-n-kjpaw_psl.0.2.UPF",
+        "md5": "d4ef18d9c8f18dc85e5843bca1e50dc0",
+        "pswfcs": [
+            "5S",
+            "5P"
+        ],
+        "semicores": []
+    },
+    "In": {
+        "filename": "In.pbe-dn-rrkjus_psl.0.2.2.UPF",
+        "md5": "25e7c42c3b55b68f4bf926be2e7201a4",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "4D"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Ir": {
+        "filename": "Ir_pbe_v1.2.uspp.F.UPF",
+        "md5": "8836f839c3459d2b385c504ce6d91f2c",
+        "pswfcs": [
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5P"
+        ]
+    },
+    "K": {
+        "filename": "K.pbe-spn-kjpaw_psl.1.0.0.UPF",
+        "md5": "7d58810084cac21f60fbe77ea2b688fd",
+        "pswfcs": [
+            "3S",
+            "4S",
+            "3P",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Kr": {
+        "filename": "Kr_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "f2280ecf57a6c8a47e066f0532d843fa",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "La": {
+        "filename": "La.paw.z_11.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "754494e15ae71f30e5b5f678af019e01",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Li": {
+        "filename": "li_pbe_v1.4.uspp.F.UPF",
+        "md5": "e912e257baa3777c20ea3d68f190483c",
+        "pswfcs": [
+            "1S",
+            "2S",
+            "2P"
+        ],
+        "semicores": [
+            "1S"
+        ]
+    },
+    "Lr": {
+        "filename": "Lr.paw.z_25.ld1.uni-marburg.v0.upf",
+        "md5": "f945946d0d1ec8347dc1259eb00091c8",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Lu": {
+        "filename": "Lu.paw.z_25.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "a517b3205eadf2aa79773283867f4cbe",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Md": {
+        "filename": "Md.paw.z_23.ld1.uni-marburg.v0.upf",
+        "md5": "e3e4fed06ac619855d80864afca10136",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Mg": {
+        "filename": "Mg.pbe-n-kjpaw_psl.0.3.0.UPF",
+        "md5": "24ecedc7f3e3cbe212e682f4413594e4",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Mn": {
+        "filename": "mn_pbe_v1.5.uspp.F.UPF",
+        "md5": "82ef2b46521d7a7d9e736dc3972e4928",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Mo": {
+        "filename": "Mo_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "1b5d28e075c9ccadda658a603575cd1f",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "N": {
+        "filename": "N.pbe-n-radius_5.UPF",
+        "md5": "16739722b17309cd8fe442a2ace49922",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Na": {
+        "filename": "na_pbe_v1.5.uspp.F.UPF",
+        "md5": "44600605ef58000f06b90626533354dc",
+        "pswfcs": [
+            "2S",
+            "2P",
+            "3S"
+        ],
+        "semicores": [
+            "2S",
+            "2P"
+        ]
+    },
+    "Nb": {
+        "filename": "Nb.pbe-spn-kjpaw_psl.0.3.0.UPF",
+        "md5": "411d72ad547312f8017e2943ceca08cc",
+        "pswfcs": [
+            "4S",
+            "5S",
+            "4P",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Nd": {
+        "filename": "Nd.paw.z_14.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "8a77231a7dfbac907351543c5ef6bfc9",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Ne": {
+        "filename": "Ne_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "9b5acc4cb48b9d80e669eadd528e4e8f",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Ni": {
+        "filename": "ni_pbe_v1.4.uspp.F.UPF",
+        "md5": "1ee80287db30b12d2bc1f57a5b5d6409",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "No": {
+        "filename": "No.paw.z_24.ld1.uni-marburg.v0.upf",
+        "md5": "75d6fcbe3c3afebd97ab105f1656d1c1",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Np": {
+        "filename": "Np.paw.z_15.ld1.uni-marburg.v0.upf",
+        "md5": "2b27845584d1ae013b107a04f9c09b5b",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "O": {
+        "filename": "O.pbe-n-kjpaw_psl.0.1.UPF",
+        "md5": "0234752ac141de4415c5fc33072bef88",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Os": {
+        "filename": "Os_pbe_v1.2.uspp.F.UPF",
+        "md5": "a3fb40a04f0c37c25c34bbc47164c9a8",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "P": {
+        "filename": "P.pbe-n-rrkjus_psl.1.0.0.UPF",
+        "md5": "8b930f418f0a4573dca56cd030ffe088",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Pa": {
+        "filename": "Pa.paw.z_13.ld1.uni-marburg.v0.upf",
+        "md5": "d7b89857b2b2f446a6f8a94fd7fc0316",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Pb": {
+        "filename": "Pb.pbe-dn-kjpaw_psl.0.2.2.UPF",
+        "md5": "9d431e6316058b74ade52399a6cf67da",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Pd": {
+        "filename": "Pd_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "eb77f42b51d86fb18e25f68156a31cf1",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Pm": {
+        "filename": "Pm.paw.z_15.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "73dcdc0c9fe91f97d1fdb9924a622ccb",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Po": {
+        "filename": "Po.pbe-dn-rrkjus_psl.1.0.0.UPF",
+        "md5": "3f8a5a8b7a531f42ca8381c21d3cd528",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Pr": {
+        "filename": "Pr.paw.z_13.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "e0f8e046fa815e336ba020f7e7bc75cb",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Pt": {
+        "filename": "pt_pbe_v1.4.uspp.F.UPF",
+        "md5": "f09d6de1a584b5a045c4fc126da2d0c4",
+        "pswfcs": [
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5P"
+        ]
+    },
+    "Pu": {
+        "filename": "Pu.paw.z_16.ld1.uni-marburg.v0.upf",
+        "md5": "566c3e560fb5ccfacef076b74913ab0c",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ra": {
+        "filename": "Ra.paw.z_20.ld1.psl.v1.0.0-high.upf",
+        "md5": "d3f31cdfcb736122946f367071bad67a",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "6S",
+            "6P",
+            "5D"
+        ]
+    },
+    "Rb": {
+        "filename": "Rb_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "55a5172d6bfbce6759a58e35d43f6aa9",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Re": {
+        "filename": "Re_pbe_v1.2.uspp.F.UPF",
+        "md5": "85f993410f3e006da9d71c142b4ad953",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Rh": {
+        "filename": "Rh_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "ba07c69523b14cacd10683cd4c4284c1",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Rn": {
+        "filename": "Rn.pbe-dn-kjpaw_psl.1.0.0.UPF",
+        "md5": "03f6b960ab99273412830d0b4aa01365",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Ru": {
+        "filename": "Ru_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "be037bb81c227cfb9b1461a9f099f4bd",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "S": {
+        "filename": "s_pbe_v1.4.uspp.F.UPF",
+        "md5": "88d86576ff6df21479756cfb9bdac1df",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Sb": {
+        "filename": "sb_pbe_v1.4.uspp.F.UPF",
+        "md5": "9bc50dfb53373b713f5709b9110fe27f",
+        "pswfcs": [
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Sc": {
+        "filename": "Sc_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "e21af8023abb52e52cb7cd3133e4a229",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Se": {
+        "filename": "Se_pbe_v1.uspp.F.UPF",
+        "md5": "1b3568f3a8ae88f9a2a0ad0698632c85",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "Si": {
+        "filename": "Si.pbe-n-rrkjus_psl.1.0.0.UPF",
+        "md5": "0b0bb1205258b0d07b9f9672cf965d36",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Sm": {
+        "filename": "Sm.paw.z_16.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "d38221e44bcfc3c784cbdb498a69732f",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Sn": {
+        "filename": "Sn_pbe_v1.uspp.F.UPF",
+        "md5": "4cf58ce39ec5d5d420df3dd08604eb00",
+        "pswfcs": [
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Sr": {
+        "filename": "Sr_pbe_v1.uspp.F.UPF",
+        "md5": "6b418c05fbe9db5448babca5e47b7a5b",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Ta": {
+        "filename": "Ta_pbe_v1.uspp.F.UPF",
+        "md5": "f8bbe9446314a3b8ea5d9f3e3836c939",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Tb": {
+        "filename": "Tb.paw.z_19.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "9e397ff4c8e7fcf344a3e57e25721bc0",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Tc": {
+        "filename": "Tc_ONCV_PBE-1.0.oncvpsp.upf",
+        "md5": "1c2b1e6c8b361b656073c0c20ed4f60a",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Te": {
+        "filename": "Te_pbe_v1.uspp.F.UPF",
+        "md5": "c319670d6894cc26e93307826a071b75",
+        "pswfcs": [
+            "5S",
+            "5P"
+        ],
+        "semicores": []
+    },
+    "Th": {
+        "filename": "Th.paw.z_12.ld1.uni-marburg.v0.upf",
+        "md5": "c778f5c1781d25750cbff4a0d60de988",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ti": {
+        "filename": "ti_pbe_v1.4.uspp.F.UPF",
+        "md5": "88a00a6731bd790ddea75d31a80cb452",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Tl": {
+        "filename": "Tl_pbe_v1.2.uspp.F.UPF",
+        "md5": "b76cf1f7e72655a2b2c53cf6385d7059",
+        "pswfcs": [
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Tm": {
+        "filename": "Tm.paw.z_23.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "65ac1a59d66520b67f41930ed0a84655",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "U": {
+        "filename": "U.paw.z_14.ld1.uni-marburg.v0.upf",
+        "md5": "0343693cc166857ace12183ecb4b0f49",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "V": {
+        "filename": "v_pbe_v1.4.uspp.F.UPF",
+        "md5": "22b79981416ebb76fdaf5b1b8640f6fb",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "W": {
+        "filename": "W_pbe_v1.2.uspp.F.UPF",
+        "md5": "9c083fa34c2a2ea0f02f1f893e16e1c8",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Xe": {
+        "filename": "Xe_ONCV_PBE-1.1.oncvpsp.upf",
+        "md5": "f6ea899d5a535d3f5731d9e48edfe3e3",
+        "pswfcs": [
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Y": {
+        "filename": "Y_pbe_v1.uspp.F.UPF",
+        "md5": "2cf71db95cafeb975fc457bd7f14888e",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Yb": {
+        "filename": "Yb.paw.z_24.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "2246be0c1287a90a9096a0c3416daab6",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Zn": {
+        "filename": "Zn_pbe_v1.uspp.F.UPF",
+        "md5": "df62231357ef9e81f77b2b3087fa5675",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Zr": {
+        "filename": "Zr_pbe_v1.uspp.F.UPF",
+        "md5": "5db81b1e868ab7776c4564c113de050b",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    }
+}

--- a/src/aiida_wannier90_workflows/utils/pseudo/data/semicore/SSSP_1.3_PBEsol_efficiency.json
+++ b/src/aiida_wannier90_workflows/utils/pseudo/data/semicore/SSSP_1.3_PBEsol_efficiency.json
@@ -1,0 +1,1431 @@
+{
+    "Ac": {
+        "filename": "Ac.us.z_11.ld1.psl.v1.0.0-high.upf",
+        "md5": "c15138f349587ceca382c8296aa5338c",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "7P",
+            "6D"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ag": {
+        "filename": "Ag_ONCV_PBEsol-1.0.upf",
+        "md5": "be0296cafe7c2d67c3292db0cbbac4d1",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Al": {
+        "filename": "Al.pbesol-n-kjpaw_psl.1.0.0.UPF",
+        "md5": "3401bcfaaf5f9b08e46a00870a1ef39d",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Am": {
+        "filename": "Am.paw.z_17.ld1.uni-marburg.v0.upf",
+        "md5": "544009e4864a75755cecfc049727c5c8",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ar": {
+        "filename": "Ar_ONCV_PBEsol-1.1.upf",
+        "md5": "c01a123fbe80b3fe80f6f94f1eb776dd",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "As": {
+        "filename": "As.pbesol-n-rrkjus_psl.0.2.UPF",
+        "md5": "1aa86e6aa4f77befd3aa87cac6788838",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "At": {
+        "filename": "At.us.z_17.ld1.psl.v1.0.0-high.upf",
+        "md5": "42fd4a20ce73a66788bd984564641bd5",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Au": {
+        "filename": "Au_ONCV_PBEsol-1.0.upf",
+        "md5": "107326c382cdbc7cf544f5ac04d81467",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "6S",
+            "5D"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "B": {
+        "filename": "b_pbesol_v1.4.uspp.F.UPF",
+        "md5": "369b69bef2c3aeed4453bd8b804fd6a8",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Ba": {
+        "filename": "Ba.pbesol-spn-kjpaw_psl.1.0.0.UPF",
+        "md5": "f28c4a63d325c1a0d00fd3a4f19b8d73",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Be": {
+        "filename": "be_pbesol_v1.4.uspp.F.UPF",
+        "md5": "09f0a726f30643f9a0ebddd893618f5c",
+        "pswfcs": [
+            "1S",
+            "2S",
+            "2P"
+        ],
+        "semicores": [
+            "1S"
+        ]
+    },
+    "Bi": {
+        "filename": "bi_pbesol_v1.uspp.F.UPF",
+        "md5": "588b87649a5c12ad5a0392deab1dcc00",
+        "pswfcs": [
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Bk": {
+        "filename": "Bk.paw.z_19.ld1.uni-marburg.v0.upf",
+        "md5": "485e52bacf8fc409e717af9f16bbd7a3",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Br": {
+        "filename": "br_pbesol_v1.4.uspp.F.UPF",
+        "md5": "7bf6084e715f6bfd1944787c04c43e72",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "C": {
+        "filename": "C.pbesol-n-kjpaw_psl.1.0.0.UPF",
+        "md5": "5f3a56537b2bcef3348431d8311bb923",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Ca": {
+        "filename": "ca_pbesol_v1.uspp.F.UPF",
+        "md5": "0533207b58cddeaa036efa5b63902087",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Cd": {
+        "filename": "Cd.pbesol-dn-rrkjus_psl.0.3.1.UPF",
+        "md5": "1f02951eb1ebb2be2329879281757063",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "4D"
+        ],
+        "semicores": []
+    },
+    "Ce": {
+        "filename": "Ce.paw.z_12.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "9051253cc2d136084ce9964e31b0ac57",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Cf": {
+        "filename": "Cf.paw.z_20.ld1.uni-marburg.v0.upf",
+        "md5": "f7ce2279b4fa9d2ad8c7f242f53d3532",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Cl": {
+        "filename": "cl_pbesol_v1.4.uspp.F.UPF",
+        "md5": "ed6bbcf06f19043c0df9f6394706ff8f",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Cm": {
+        "filename": "Cm.paw.z_18.ld1.uni-marburg.v0.upf",
+        "md5": "a1a4efba38350bb0799c9bf72c6c5a9e",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Co": {
+        "filename": "co_pbesol_v1.2.uspp.F.UPF",
+        "md5": "3b4cd4e7cc7df4da9fdede0fd33e2193",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Cr": {
+        "filename": "cr_pbesol_v1.5.uspp.F.UPF",
+        "md5": "a621641e0be27168676a837af8893d0f",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Cs": {
+        "filename": "cs_pbesol_v1.uspp.F.UPF",
+        "md5": "ae4559e5c840913b791237f814e2d884",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Cu": {
+        "filename": "Cu.paw.z_11.ld1.psl.v1.0.0-low.upf",
+        "md5": "e985f55843d4aeb8486834e0a057895d",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "3D"
+        ],
+        "semicores": []
+    },
+    "Dy": {
+        "filename": "Dy.paw.z_20.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "f0d323c86057a5ffc0f74ac83d54d650",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Er": {
+        "filename": "Er.paw.z_22.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "3d5fe14767f74d36bf4904614a37904f",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Es": {
+        "filename": "Es.paw.z_21.ld1.uni-marburg.v0.upf",
+        "md5": "59d79d83f25bcd9b9038574a0e694f7e",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Eu": {
+        "filename": "Eu.paw.z_17.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "7a3470e714d369b4ca83128fd03579b7",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "F": {
+        "filename": "f_pbesol_v1.4.uspp.F.UPF",
+        "md5": "d2815ecb49b17b99c5724ffd2f9bbd8d",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Fe": {
+        "filename": "Fe.pbesol-spn-kjpaw_psl.0.2.1.UPF",
+        "md5": "4d7ec5aa2156491519a4322664fbbf52",
+        "pswfcs": [
+            "3S",
+            "4S",
+            "3P",
+            "4P",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Fm": {
+        "filename": "Fm.paw.z_22.ld1.uni-marburg.v0.upf",
+        "md5": "b4edc3438488d73bd00d9992411fff9f",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Fr": {
+        "filename": "Fr.paw.z_19.ld1.psl.v1.0.0-high.upf",
+        "md5": "117900fe13ddb22c1000680025385f46",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "6S",
+            "6P",
+            "5D"
+        ]
+    },
+    "Ga": {
+        "filename": "Ga.pbesol-dn-kjpaw_psl.1.0.0.UPF",
+        "md5": "2a7819223b42fad6ccd7f29fc9cbee49",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "3D"
+        ],
+        "semicores": [
+            "3D"
+        ]
+    },
+    "Gd": {
+        "filename": "Gd.paw.z_18.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "0015802defb1cb74d7c9944c2f27f10e",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Ge": {
+        "filename": "ge_pbesol_v1.4.uspp.F.UPF",
+        "md5": "7bed0412183f5e553a4d27ec7023354d",
+        "pswfcs": [
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3D"
+        ]
+    },
+    "H": {
+        "filename": "H.pbesol-rrkjus_psl.1.0.0.UPF",
+        "md5": "0324ed591cc0147dc3d88cad0d33f665",
+        "pswfcs": [
+            "1S"
+        ],
+        "semicores": []
+    },
+    "He": {
+        "filename": "He_ONCV_PBEsol-1.0.upf",
+        "md5": "3a98d7dc8e9b0e8c7e1be02b8995cc9d",
+        "pswfcs": [
+            "1S"
+        ],
+        "semicores": []
+    },
+    "Hf": {
+        "filename": "Hf-sp.oncvpsp.upf",
+        "md5": "3619c98de2ee908b1d969add25be4863",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Hg": {
+        "filename": "Hg_ONCV_PBEsol-1.0.upf",
+        "md5": "9b18bbaf32e5d8994dbbbf1f0a8e2d63",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "6S",
+            "5D"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Ho": {
+        "filename": "Ho.paw.z_21.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "48b6df5b4ba39ef8b782e62372020711",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "I": {
+        "filename": "I.pbesol-n-kjpaw_psl.0.2.UPF",
+        "md5": "cecf1a22a184a0b1ae701638a037a48d",
+        "pswfcs": [
+            "5S",
+            "5P"
+        ],
+        "semicores": []
+    },
+    "In": {
+        "filename": "In.pbesol-dn-rrkjus_psl.0.2.2.UPF",
+        "md5": "2a3399a31491503da6b8c7d8e01e9843",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "4D"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Ir": {
+        "filename": "ir_pbesol_v1.2.uspp.F.UPF",
+        "md5": "965d8bb5733ec2587acb56a50491f36d",
+        "pswfcs": [
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5P"
+        ]
+    },
+    "K": {
+        "filename": "K.pbesol-spn-kjpaw_psl.1.0.0.UPF",
+        "md5": "b302bede38c4f5fe00638ceae66f121b",
+        "pswfcs": [
+            "3S",
+            "4S",
+            "3P",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Kr": {
+        "filename": "Kr_ONCV_PBEsol-1.0.upf",
+        "md5": "5ac180be35b0c9edbb375e438c4855d9",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "La": {
+        "filename": "La.paw.z_11.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "bf5f3bee57a2a6e198b760bfd6266ed7",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Li": {
+        "filename": "li_pbesol_v1.4.uspp.F.UPF",
+        "md5": "aa28d9aeea6a965f2dc95ee9517b3536",
+        "pswfcs": [
+            "1S",
+            "2S",
+            "2P"
+        ],
+        "semicores": [
+            "1S"
+        ]
+    },
+    "Lr": {
+        "filename": "Lr.paw.z_25.ld1.uni-marburg.v0.upf",
+        "md5": "29a152f2015609634c2e852a82c5a4f5",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Lu": {
+        "filename": "Lu.paw.z_25.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "0a2085320d381d713338075912e54214",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Md": {
+        "filename": "Md.paw.z_23.ld1.uni-marburg.v0.upf",
+        "md5": "5624d91aafaa2b4f8161f4c4ce054b4b",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Mg": {
+        "filename": "Mg.pbesol-n-kjpaw_psl.0.3.0.UPF",
+        "md5": "a6c8d2ff726a5f7005dea00130d82930",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Mn": {
+        "filename": "mn_pbesol_v1.5.uspp.F.UPF",
+        "md5": "0716d5f563e6e95a34f9080f4c78c109",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Mo": {
+        "filename": "Mo_ONCV_PBEsol-1.0.upf",
+        "md5": "5193ba6a20874d27c2ef80314d1b3445",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "N": {
+        "filename": "N.pbesol-theos.UPF",
+        "md5": "1b64827339d390a5a22afef3ff345c9d",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Na": {
+        "filename": "na_pbesol_v1.5.uspp.F.UPF",
+        "md5": "164b46c7694b4bc5b1217b5d1ae6f423",
+        "pswfcs": [
+            "2S",
+            "2P",
+            "3S"
+        ],
+        "semicores": [
+            "2S",
+            "2P"
+        ]
+    },
+    "Nb": {
+        "filename": "Nb.pbesol-spn-kjpaw_psl.0.3.0.UPF",
+        "md5": "3501bca1474143575298708b2d32ca28",
+        "pswfcs": [
+            "4S",
+            "5S",
+            "4P",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Nd": {
+        "filename": "Nd.paw.z_14.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "a7c1537a22ad7eff212e65b6bddb3dd0",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Ne": {
+        "filename": "Ne_ONCV_PBEsol-1.0.upf",
+        "md5": "6b58c9748b6c6bd8518a05c4ffec2876",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Ni": {
+        "filename": "ni_pbesol_v1.4.uspp.F.UPF",
+        "md5": "de937c0c8ae4b350e69c02b76d8a83cb",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "No": {
+        "filename": "No.paw.z_24.ld1.uni-marburg.v0.upf",
+        "md5": "3b7bd72b58165fa4bd05b1a5d6eec8fa",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Np": {
+        "filename": "Np.paw.z_15.ld1.uni-marburg.v0.upf",
+        "md5": "76f460f12933aeb8f74ad9114b784412",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "O": {
+        "filename": "O.pbesol-n-kjpaw_psl.0.1.UPF",
+        "md5": "81d73d1479e654e5638b0319f0d6c2c7",
+        "pswfcs": [
+            "2S",
+            "2P"
+        ],
+        "semicores": []
+    },
+    "Os": {
+        "filename": "os_pbesol_v1.2.uspp.F.UPF",
+        "md5": "417375b0b6115d11b925f9c92882b8df",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "P": {
+        "filename": "P.pbesol-n-rrkjus_psl.1.0.0.UPF",
+        "md5": "bbb94b1b16383820d6a769669b5d42db",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Pa": {
+        "filename": "Pa.paw.z_13.ld1.uni-marburg.v0.upf",
+        "md5": "e9582332a4d588771957bd3d80577540",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Pb": {
+        "filename": "Pb.pbesol-dn-kjpaw_psl.0.2.2.UPF",
+        "md5": "df0e0ac60519e244e20a4bf230ae894d",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Pd": {
+        "filename": "Pd_ONCV_PBEsol-1.0.upf",
+        "md5": "252ac589d0cc8911379e98310815452c",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Pm": {
+        "filename": "Pm.paw.z_15.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "e3d819ac42e7abfca6485afda6326075",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Po": {
+        "filename": "Po.pbesol-dn-rrkjus_psl.1.0.0.UPF",
+        "md5": "699150f1cfd13117cb33a6caa4356c05",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Pr": {
+        "filename": "Pr.paw.z_13.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "ea5c6275c651088c0a4cd288e635891b",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Pt": {
+        "filename": "pt_pbesol_v1.4.uspp.F.UPF",
+        "md5": "d14d547907f752a992688280a7473f8c",
+        "pswfcs": [
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5P"
+        ]
+    },
+    "Pu": {
+        "filename": "Pu.paw.z_16.ld1.uni-marburg.v0.upf",
+        "md5": "4364d414263234fb84d47bd73facc432",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ra": {
+        "filename": "Ra.paw.z_20.ld1.psl.v1.0.0-high.upf",
+        "md5": "238d211ec2be30dba2ceb18bd820b9a7",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "6S",
+            "6P",
+            "5D"
+        ]
+    },
+    "Rb": {
+        "filename": "Rb_ONCV_PBEsol-1.0.upf",
+        "md5": "84df3c5f64297d00eda9a2a6a50301db",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Re": {
+        "filename": "re_pbesol_v1.2.uspp.F.UPF",
+        "md5": "aaf9138663fa2d46e1797bae542d0e3d",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Rh": {
+        "filename": "Rh_ONCV_PBEsol-1.0.upf",
+        "md5": "ec594c1794ddd2e1e7b303db34a9ee92",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Rn": {
+        "filename": "Rn.pbesol-dn-kjpaw_psl.1.0.0.UPF",
+        "md5": "5c61dddfb132b66dc3f68191c02785a8",
+        "pswfcs": [
+            "6S",
+            "6P",
+            "5D"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Ru": {
+        "filename": "Ru_ONCV_PBEsol-1.0.upf",
+        "md5": "8f986bf37b5af91b2f53a4f9afee5fd8",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "S": {
+        "filename": "s_pbesol_v1.4.uspp.F.UPF",
+        "md5": "0ccfa86ec6eb59065d10aaae963ef2a7",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Sb": {
+        "filename": "sb_pbesol_v1.4.uspp.F.UPF",
+        "md5": "b66a27f2c95be5fc87b0bb5ef8c6d7fd",
+        "pswfcs": [
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Sc": {
+        "filename": "Sc_ONCV_PBEsol-1.0.upf",
+        "md5": "1a9da10301537f29e8fd13e102309a15",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Se": {
+        "filename": "se_pbesol_v1.uspp.F.UPF",
+        "md5": "a3b4745ad650bb7419ce2e0d5f176975",
+        "pswfcs": [
+            "4S",
+            "4P"
+        ],
+        "semicores": []
+    },
+    "Si": {
+        "filename": "Si.pbesol-n-rrkjus_psl.1.0.0.UPF",
+        "md5": "c4212819de858c94c3a1644338846ac9",
+        "pswfcs": [
+            "3S",
+            "3P"
+        ],
+        "semicores": []
+    },
+    "Sm": {
+        "filename": "Sm.paw.z_16.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "04193d55a4ecd610690a43e02958305e",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Sn": {
+        "filename": "sn_pbesol_v1.4.uspp.F.UPF",
+        "md5": "463fec1d5456f1e96ec1bfcad4b7b038",
+        "pswfcs": [
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Sr": {
+        "filename": "sr_pbesol_v1.uspp.F.UPF",
+        "md5": "635bff1625df5273dba4129a01ed8c82",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Ta": {
+        "filename": "ta_pbesol_v1.uspp.F.UPF",
+        "md5": "5dd23d6859724cbb2c0d9b6294d5f84c",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Tb": {
+        "filename": "Tb.paw.z_19.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "5a6e35f99376ffe0fc87b28e89eaa2e9",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Tc": {
+        "filename": "Tc_ONCV_PBEsol-1.0.upf",
+        "md5": "e1002180990b9df3eeb3e08c45184084",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "5S",
+            "4D"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Te": {
+        "filename": "te_pbesol_v1.uspp.F.UPF",
+        "md5": "44ee7635674656c288d8e9a9a9ffd7e3",
+        "pswfcs": [
+            "5S",
+            "5P"
+        ],
+        "semicores": []
+    },
+    "Th": {
+        "filename": "Th.paw.z_12.ld1.uni-marburg.v0.upf",
+        "md5": "0f66dad6a8c736814a21f761e43cf895",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "Ti": {
+        "filename": "ti_pbesol_v1.4.uspp.F.UPF",
+        "md5": "193cf2c0c3c6a4da613d69453fa7e3e9",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Tl": {
+        "filename": "tl_pbesol_v1.2.uspp.F.UPF",
+        "md5": "ce331abb17083e2469b5604a64700343",
+        "pswfcs": [
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5D"
+        ]
+    },
+    "Tm": {
+        "filename": "Tm.paw.z_23.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "d87dc3e161121ee54c6528111a2c64f9",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "U": {
+        "filename": "U.paw.z_14.ld1.uni-marburg.v0.upf",
+        "md5": "ac07155b0c4ef44a0fce3f7556d38735",
+        "pswfcs": [
+            "6S",
+            "7S",
+            "6P",
+            "6D",
+            "5F"
+        ],
+        "semicores": [
+            "6S",
+            "6P"
+        ]
+    },
+    "V": {
+        "filename": "v_pbesol_v1.4.uspp.F.UPF",
+        "md5": "72fa7d0034c41d8adc50bbc8c632b9f9",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "4S",
+            "3D"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "W": {
+        "filename": "w_pbesol_v1.2.uspp.F.UPF",
+        "md5": "78d6efd6ad550bd5be97e9711072ceda",
+        "pswfcs": [
+            "5S",
+            "5P",
+            "5D",
+            "6S",
+            "6P"
+        ],
+        "semicores": [
+            "5S",
+            "5P"
+        ]
+    },
+    "Xe": {
+        "filename": "Xe_ONCV_PBEsol-1.1.upf",
+        "md5": "ed053c2ceb368a0b775438b7c863d821",
+        "pswfcs": [
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4D"
+        ]
+    },
+    "Y": {
+        "filename": "y_pbesol_v1.4.uspp.F.UPF",
+        "md5": "dac24993bfd4491f22c7b9129ad9e93d",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    },
+    "Yb": {
+        "filename": "Yb.paw.z_24.atompaw.wentzcovitch.v1.2.upf",
+        "md5": "99544937f199e08ce7c7ae457e6681d8",
+        "pswfcs": [
+            "5S",
+            "6S",
+            "5P",
+            "0P",
+            "5D",
+            "0D",
+            "4F",
+            "0F"
+        ],
+        "semicores": [
+            "5S",
+            "5P",
+            "0P",
+            "0D",
+            "0F"
+        ]
+    },
+    "Zn": {
+        "filename": "zn_pbesol_v1.uspp.F.UPF",
+        "md5": "7d8615e52efe7c1e2b1899de8658bae2",
+        "pswfcs": [
+            "3S",
+            "3P",
+            "3D",
+            "4S",
+            "4P"
+        ],
+        "semicores": [
+            "3S",
+            "3P"
+        ]
+    },
+    "Zr": {
+        "filename": "zr_pbesol_v1.uspp.F.UPF",
+        "md5": "f29f2a20533738a515abe666fee35838",
+        "pswfcs": [
+            "4S",
+            "4P",
+            "4D",
+            "5S",
+            "5P"
+        ],
+        "semicores": [
+            "4S",
+            "4P"
+        ]
+    }
+}

--- a/src/aiida_wannier90_workflows/workflows/protocols/base/wannier90.yaml
+++ b/src/aiida_wannier90_workflows/workflows/protocols/base/wannier90.yaml
@@ -9,7 +9,7 @@ default_inputs:
         num_bands_factor: 2.0
         kpoints_distance: 0.2
         kpoints_force_parity: False
-        pseudo_family: 'SSSP/1.1/PBE/efficiency'
+        pseudo_family: 'SSSP/1.3/PBEsol/efficiency'
         exclude_semicore: True
     wannier90:
         metadata:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def pseudos(aiida_profile, generate_upf_data, generate_upf_data_soc):
     SsspFamily = GroupFactory("pseudo.family.sssp")
 
     stringency = "standard"
-    label = "SSSP/1.1/PBE/efficiency"
+    label = "SSSP/1.3/PBEsol/efficiency"
     sssp = SsspFamily(label=label)
     sssp.store()
 
@@ -273,16 +273,16 @@ def generate_upf_data_soc(filepath_fixtures):
 
 @pytest.fixture(scope="session")
 def get_sssp_upf():
-    """Returen a SSSP pseudo with a given element name."""
+    """Return a SSSP pseudo with a given element name."""
 
     def _get_sssp_upf(element):
-        """Returen SSSP pseudo."""
+        """Return SSSP pseudo."""
         from aiida.orm import QueryBuilder
         from aiida.plugins import GroupFactory
 
         SsspFamily = GroupFactory("pseudo.family.sssp")
 
-        label = "SSSP/1.1/PBE/efficiency"
+        label = "SSSP/1.3/PBEsol/efficiency"
         pseudo_family = (
             QueryBuilder().append(SsspFamily, filters={"label": label}).one()[0]
         )
@@ -354,7 +354,7 @@ def generate_calc_job_node(fixture_localhost, filepath_fixtures):
                 flat_inputs.append((prefix + key, value))
         return flat_inputs
 
-    def _generate_calc_job_node(
+    def _generate_calc_job_node(  # pylint: disable=too-many-positional-arguments
         entry_point_name="base",
         computer=None,
         test_name=None,


### PR DESCRIPTION
Add a function for semicore list generation supporting UPF v1 and v2
  * Add `__init__.py` file to the semicore dolder so the location can be deduced from the import
  * Generate the semicore data for SSSP v1.3 PBE and PBEsol efficiency
    I checked that for the elements where md5 is the same for v1.1 and 1.3, the list of orbitals and semicores is the same

Note: the new function could maybe replace the PSHandler class since it can also read UPF version 1
 
Adjust the default protocol to use SSSP/1.3/PBEsol/efficiency

Install SSSP v1.3 PBEsol for tests

This would fix #65 
