### PR TITLE
Added the options values to the `projwfc` builder.

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/projwfcbands.py
+++ b/src/aiida_wannier90_workflows/workflows/projwfcbands.py
@@ -136,8 +136,11 @@ class ProjwfcBandsWorkChain(PwBandsWorkChain):
         pwbands_builder.pop("relax", None)
 
         projwfc_builder = ProjwfcBaseWorkChain.get_builder_from_protocol(
-            projwfc_code, protocol=protocol, overrides=projwfc_overrides
+            projwfc_code,
+            protocol=protocol,
+            overrides=projwfc_overrides,
         )
+        projwfc_builder["projwfc"]["metadata"]["options"] = kwargs.get("options", {})
         projwfc_builder.pop("clean_workdir", None)
 
         builder.projwfc = projwfc_builder


### PR DESCRIPTION
Hey All, 

I noticed that when using the `ProjwfcBandsWorkChain`, the `options` parameters set on the builder are correctly propagated to the SCF and bands calculations, but not to the final projwfc calculation. This can be a bit annoying during testing, since everything runs on the debug queue except the last step.
Happy to hear your thoughts!