### PR TITLE
Fast protocol: decrease kpoint distance and disabe optimize_disproj

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -36,6 +36,8 @@ def validate_inputs(inputs, ctx=None):  # pylint: disable=unused-argument
     if optimize_disproj:
         if all(_ not in parameters for _ in ("dis_proj_min", "dis_proj_max")):
             return "Trying to optimize dis_proj_min/max but no dis_proj_min/max in wannier90 parameters?"
+        if "`optimize_reference_bands`" not in inputs:
+            return "Trying to optimize dis_proj_min/max but no `optimize_reference_bands` provided for checking bands distance?"
 
     if "optimize_reference_bands" in inputs and not optimize_disproj:
         warnings.warn(

--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -342,9 +342,12 @@ class Wannier90OptimizeWorkChain(
         builder = cls.get_builder()
         builder._data = parent_builder._data  # pylint: disable=protected-access
 
+        # Preserve optimize-specific protocol inputs which are not part of
+        # the parent builder namespace and therefore are not copied above.
+        builder.optimize_disproj = inputs.get("optimize_disproj", True)
+
         # Inputs for optimizing dis_proj_min/max
         if reference_bands:
-            builder.optimize_disproj = True
             builder.optimize_reference_bands = reference_bands
             builder.optimize_bands_distance_threshold = bands_distance_threshold
 

--- a/src/aiida_wannier90_workflows/workflows/protocols/base/wannier90.yaml
+++ b/src/aiida_wannier90_workflows/workflows/protocols/base/wannier90.yaml
@@ -46,7 +46,7 @@ protocols:
             conv_tol_per_atom: 1.e-5
             dis_conv_tol_per_atom: 1.e-5
             num_bands_factor: 1.2
-            kpoints_distance: 0.5
+            kpoints_distance: 0.4
         wannier90:
             parameters:
                 conv_window: 1

--- a/src/aiida_wannier90_workflows/workflows/protocols/optimize.yaml
+++ b/src/aiida_wannier90_workflows/workflows/protocols/optimize.yaml
@@ -1,5 +1,6 @@
 default_inputs:
     clean_workdir: False
+    optimize_disproj: True
 default_protocol: moderate
 protocols:
     moderate:
@@ -8,3 +9,4 @@ protocols:
         description: 'Protocol to perform the computation at high precision at higher computational cost.'
     fast:
         description: 'Protocol to perform the computation at low precision at minimal computational cost for testing purposes.'
+        optimize_disproj: False

--- a/tests/workflows/protocols/test_optimize.py
+++ b/tests/workflows/protocols/test_optimize.py
@@ -24,6 +24,17 @@ def test_get_default_protocol():
     assert Wannier90OptimizeWorkChain.get_default_protocol() == "moderate"
 
 
+def test_fast_protocol_optimize_disproj_disabled(generate_builder_inputs):
+    """Test ``protocol='fast'`` sets ``optimize_disproj`` to ``False``."""
+    builder = Wannier90OptimizeWorkChain.get_builder_from_protocol(
+        **generate_builder_inputs(),
+        protocol="fast",
+        print_summary=False,
+    )
+
+    assert builder.optimize_disproj.value is False
+
+
 @pytest.mark.parametrize("structure", ("Si", "H2O", "GaAs", "BaTiO3"))
 def test_atomic_projectors_qe(
     generate_builder_inputs, data_regression, serialize_builder, structure

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_BaTiO3_.yml
@@ -39,6 +39,7 @@ nscf:
       Ba: Ba.pbe-spn-kjpaw_psl.1.0.0.UPF
       O: O.pbe-n-kjpaw_psl.0.1.UPF
       Ti: ti_pbe_v1.4.uspp.F.UPF
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_GaAs_.yml
@@ -38,6 +38,7 @@ nscf:
     pseudos:
       As: As.pbe-n-rrkjus_psl.0.2.UPF
       Ga: Ga.pbe-dn-kjpaw_psl.1.0.0.UPF
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_H2O_.yml
@@ -38,6 +38,7 @@ nscf:
     pseudos:
       H: H.pbe-rrkjus_psl.1.0.0.UPF
       O: O.pbe-n-kjpaw_psl.0.1.UPF
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_Si_.yml
@@ -37,6 +37,7 @@ nscf:
         smearing: cold
     pseudos:
       Si: Si.pbe-n-rrkjus_psl.1.0.0.UPF
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
@@ -41,6 +41,7 @@ nscf:
       Ba: Ba.upf
       O: O.upf
       Ti: Ti.upf
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
@@ -40,6 +40,7 @@ nscf:
     pseudos:
       As: As.upf
       Ga: Ga.upf
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
@@ -40,6 +40,7 @@ nscf:
     pseudos:
       H: H.upf
       O: O.upf
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
@@ -39,6 +39,7 @@ nscf:
         smearing: cold
     pseudos:
       Si: Si.upf
+optimize_disproj: true
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost


### PR DESCRIPTION
This pull request introduces improvements to the Wannier90 optimization workflow, focusing on better protocol customization and ensuring protocol-specific options are correctly handled. Key changes include making the `optimize_disproj` input protocol-aware, updating protocol defaults, and adding a test to verify the correct behavior.

**Protocol customization and defaults:**
- Set `optimize_disproj` to `True` by default in `default_inputs` and explicitly set it to `False` for the `fast` protocol in `optimize.yaml`, allowing protocol-specific control over this option. [[1]](diffhunk://#diff-74f70948a051e55d44f3e8f8209a259ccc7ffff97189a3662ababb814ec61165R3) [[2]](diffhunk://#diff-74f70948a051e55d44f3e8f8209a259ccc7ffff97189a3662ababb814ec61165R12)
- Updated the `kpoints_distance` parameter in the moderate protocol of `wannier90.yaml` from `0.5` to `0.4` for improved precision.

**Workflow logic:**
- Modified `get_builder_from_protocol` to correctly preserve and set `optimize_disproj` from protocol inputs, ensuring it is not overwritten when reference bands are provided.

**Testing:**
- Added a test to confirm that the `fast` protocol sets `optimize_disproj` to `False`, ensuring protocol-specific behavior is respected.