### PR TITLE
Fix typo on `optimize_reference_bands` input

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -36,7 +36,7 @@ def validate_inputs(inputs, ctx=None):  # pylint: disable=unused-argument
     if optimize_disproj:
         if all(_ not in parameters for _ in ("dis_proj_min", "dis_proj_max")):
             return "Trying to optimize dis_proj_min/max but no dis_proj_min/max in wannier90 parameters?"
-        if "`optimize_reference_bands`" not in inputs:
+        if "optimize_reference_bands" not in inputs:
             return "Trying to optimize dis_proj_min/max but no `optimize_reference_bands` provided for checking bands distance?"
 
     if "optimize_reference_bands" in inputs and not optimize_disproj:


### PR DESCRIPTION
This pull request makes a small but important fix to the input validation logic in `src/aiida_wannier90_workflows/workflows/optimize.py`. The change corrects a bug in the way the code checks for the presence of the `optimize_reference_bands` key in the `inputs` dictionary.

* Fixed a bug in the `validate_inputs` function by removing unnecessary backticks from the `"optimize_reference_bands"` key check, ensuring the presence of the correct key is validated in `inputs`.