### PR TITLE
Remove soc pwbase workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.9"
 dependencies = [
     "aiida-core>=2.0,<3",
     "aiida-pseudo>=0.6",
-    "aiida-quantumespresso>=4.4",
+    "aiida-quantumespresso>=4.12",
     "aiida-wannier90>=2.2",
     "click>=8.0",
     "colorama"

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -478,29 +478,15 @@ class Wannier90WorkChain(
                     ]["pseudo_family"]
                 )
 
-        # As PwBaseWorkChain.get_builder_from_protocol() does not support SOC, we have to pass the
-        # desired parameters through the overrides. In this case we need to set the `pw.x`
-        # spin_type to SpinType.NONE, otherwise the builder will raise an error.
-        # This block should be removed once SOC is supported in PwBaseWorkChain.
+        # PwBaseWorkChain.get_builder_from_protocol handles SOC/non-collinear natively
+        # (sets noncolin/nspin/lspinorb and seeds starting_magnetization), so pass
+        # spin_type straight through. SOC is magnetically initialized by default.
         spin_orbit_coupling = spin_type == SpinType.SPIN_ORBIT
         spin_non_collinear = (
             spin_type == SpinType.NON_COLLINEAR
         ) or spin_orbit_coupling
 
-        if spin_type == SpinType.NON_COLLINEAR:
-            overrides = recursive_merge(
-                protocol_overrides["spin_noncollinear"], overrides
-            )
-        if spin_type == SpinType.SPIN_ORBIT:
-            overrides = recursive_merge(protocol_overrides["spin_orbit"], overrides)
-            if (initial_magnetic_moments is not None) or any(
-                "magmom" in kind for kind in structure.base.attributes.all["kinds"]
-            ):
-                pw_spin_type = SpinType.NON_COLLINEAR
-            else:
-                pw_spin_type = SpinType.NONE
-        else:
-            pw_spin_type = spin_type
+        pw_spin_type = spin_type
 
         inputs = cls.get_protocol_inputs(protocol=protocol, overrides=overrides)
 

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_BaTiO3_.yml
@@ -27,6 +27,14 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
+        angle2:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +43,13 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Ba: 0.1
+          O: 0.1
+          Ti: 0.4166666666666667
     pseudos:
       Ba: Ba.upf
       O: O.upf
@@ -91,14 +104,27 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
+        angle2:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Ba: 0.1
+          O: 0.1
+          Ti: 0.4166666666666667
     pseudos:
       Ba: Ba.upf
       O: O.upf

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_GaAs_.yml
@@ -27,6 +27,12 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          As: 0.0
+          Ga: 0.0
+        angle2:
+          As: 0.0
+          Ga: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +41,12 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          As: 0.1
+          Ga: 0.1
     pseudos:
       As: As.upf
       Ga: Ga.upf
@@ -90,14 +100,24 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          As: 0.0
+          Ga: 0.0
+        angle2:
+          As: 0.0
+          Ga: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          As: 0.1
+          Ga: 0.1
     pseudos:
       As: As.upf
       Ga: Ga.upf

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_H2O_.yml
@@ -27,6 +27,12 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          H: 0.0
+          O: 0.0
+        angle2:
+          H: 0.0
+          O: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +41,12 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          H: 0.1
+          O: 0.1
     pseudos:
       H: H.upf
       O: O.upf
@@ -90,14 +100,24 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          H: 0.0
+          O: 0.0
+        angle2:
+          H: 0.0
+          O: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          H: 0.1
+          O: 0.1
     pseudos:
       H: H.upf
       O: O.upf

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_Si_.yml
@@ -27,6 +27,10 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          Si: 0.0
+        angle2:
+          Si: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +39,11 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Si: 0.1
     pseudos:
       Si: Si.upf
 projwfc:
@@ -89,14 +96,21 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          Si: 0.0
+        angle2:
+          Si: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Si: 0.1
     pseudos:
       Si: Si.upf
 structure: Si2

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
@@ -27,6 +27,14 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
+        angle2:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +43,13 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Ba: 0.1
+          O: 0.1
+          Ti: 0.4166666666666667
     pseudos:
       Ba: Ba.upf
       O: O.upf
@@ -96,14 +109,27 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
+        angle2:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Ba: 0.1
+          O: 0.1
+          Ti: 0.4166666666666667
     pseudos:
       Ba: Ba.upf
       O: O.upf

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
@@ -27,6 +27,12 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          As: 0.0
+          Ga: 0.0
+        angle2:
+          As: 0.0
+          Ga: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +41,12 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          As: 0.1
+          Ga: 0.1
     pseudos:
       As: As.upf
       Ga: Ga.upf
@@ -99,14 +109,24 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          As: 0.0
+          Ga: 0.0
+        angle2:
+          As: 0.0
+          Ga: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          As: 0.1
+          Ga: 0.1
     pseudos:
       As: As.upf
       Ga: Ga.upf

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
@@ -27,6 +27,12 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          H: 0.0
+          O: 0.0
+        angle2:
+          H: 0.0
+          O: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +41,12 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          H: 0.1
+          O: 0.1
     pseudos:
       H: H.upf
       O: O.upf
@@ -78,14 +88,24 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          H: 0.0
+          O: 0.0
+        angle2:
+          H: 0.0
+          O: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          H: 0.1
+          O: 0.1
     pseudos:
       H: H.upf
       O: O.upf

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
@@ -27,6 +27,10 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          Si: 0.0
+        angle2:
+          Si: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +39,11 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Si: 0.1
     pseudos:
       Si: Si.upf
 optimize_disproj: true
@@ -77,14 +84,21 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          Si: 0.0
+        angle2:
+          Si: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Si: 0.1
     pseudos:
       Si: Si.upf
 structure: Si2

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_BaTiO3_.yml
@@ -27,6 +27,14 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
+        angle2:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +43,13 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Ba: 0.1
+          O: 0.1
+          Ti: 0.4166666666666667
     pseudos:
       Ba: Ba.upf
       O: O.upf
@@ -91,14 +104,27 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
+        angle2:
+          Ba: 0.0
+          O: 0.0
+          Ti: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Ba: 0.1
+          O: 0.1
+          Ti: 0.4166666666666667
     pseudos:
       Ba: Ba.upf
       O: O.upf

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_GaAs_.yml
@@ -27,6 +27,12 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          As: 0.0
+          Ga: 0.0
+        angle2:
+          As: 0.0
+          Ga: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +41,12 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          As: 0.1
+          Ga: 0.1
     pseudos:
       As: As.upf
       Ga: Ga.upf
@@ -90,14 +100,24 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          As: 0.0
+          Ga: 0.0
+        angle2:
+          As: 0.0
+          Ga: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          As: 0.1
+          Ga: 0.1
     pseudos:
       As: As.upf
       Ga: Ga.upf

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_H2O_.yml
@@ -27,6 +27,12 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          H: 0.0
+          O: 0.0
+        angle2:
+          H: 0.0
+          O: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +41,12 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          H: 0.1
+          O: 0.1
     pseudos:
       H: H.upf
       O: O.upf
@@ -90,14 +100,24 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          H: 0.0
+          O: 0.0
+        angle2:
+          H: 0.0
+          O: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          H: 0.1
+          O: 0.1
     pseudos:
       H: H.upf
       O: O.upf

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_Si_.yml
@@ -27,6 +27,10 @@ nscf:
         mixing_beta: 0.4
         startingpot: file
       SYSTEM:
+        angle1:
+          Si: 0.0
+        angle2:
+          Si: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
@@ -35,8 +39,11 @@ nscf:
         noinv: true
         noncolin: true
         nosym: true
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Si: 0.1
     pseudos:
       Si: Si.upf
 projwfc:
@@ -89,14 +96,21 @@ scf:
         electron_maxstep: 80
         mixing_beta: 0.4
       SYSTEM:
+        angle1:
+          Si: 0.0
+        angle2:
+          Si: 0.0
         degauss: 0.02
         ecutrho: 300.0
         ecutwfc: 40.0
         lspinorb: true
         noncolin: true
         nosym: false
+        nspin: 4
         occupations: smearing
         smearing: cold
+        starting_magnetization:
+          Si: 0.1
     pseudos:
       Si: Si.upf
 structure: Si2


### PR DESCRIPTION
Remove SOC workaround in Wannier90WorkChain.get_builder_from_protocol

`PwBaseWorkChain.get_builder_from_protocol` now supports non-collinear and spin-orbit calculations natively (added in aiida-quantumespresso v4.12.0, commit aiidateam/aiida-quantumespresso@0c81dad). It sets `noncolin`/`nspin`/`lspinorb` and seeds `starting_magnetization` from `initial_magnetic_moments`, the structure's magmoms, or the per-element defaults.

This PR removes the workaround in `Wannier90WorkChain.get_builder_from_protocol`.  We now pass `spin_type`
straight through to the scf/nscf builders and let `PwBaseWorkChain` handle it.

SOC calculations are now **magnetically initialized by default**. Previously the workaround produced a *non-magnetic* SOC calculation (only `lspinorb`/`noncolin`, no `starting_magnetization`). Regenerated the fixtures to comply with these changes in the spin orbit case. Please let me know what you think 😃 
