### PR TITLE
Adapt namelist parameter case to match aiida-quantumespresso v5

### DIFF
--- a/src/aiida_wannier90_workflows/utils/workflows/plot/bands.py
+++ b/src/aiida_wannier90_workflows/utils/workflows/plot/bands.py
@@ -160,8 +160,8 @@ def read_band_proj_sigma_mu_from_workchain(
     projections = projcalc.outputs[f"projections{spin_component}"]
     bands = projcalc.outputs[f"bands{spin_component}"]
 
-    sigma = p2wcalc.inputs.parameters["inputpp"]["scdm_sigma"]
-    mu = p2wcalc.inputs.parameters["inputpp"]["scdm_mu"]
+    sigma = p2wcalc.inputs.parameters["INPUTPP"]["scdm_sigma"]
+    mu = p2wcalc.inputs.parameters["INPUTPP"]["scdm_mu"]
 
     results = {"bands": bands, "projections": projections, "sigma": sigma, "mu": mu}
     return results

--- a/src/aiida_wannier90_workflows/workflows/base/pw2wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/pw2wannier90.py
@@ -38,7 +38,7 @@ def validate_inputs(  # pylint: disable=unused-argument,inconsistent-return-stat
         return result
 
     calc_inputs = AttributeDict(inputs[Pw2wannier90BaseWorkChain._inputs_namespace])
-    calc_parameters = calc_inputs["parameters"].get_dict().get("inputpp", {})
+    calc_parameters = calc_inputs["parameters"].get_dict().get("INPUTPP", {})
 
     scdm_proj = calc_parameters.get("scdm_proj", False)
     scdm_entanglement = calc_parameters.get("scdm_entanglement", "isolated")
@@ -165,7 +165,7 @@ class Pw2wannier90BaseWorkChain(ProtocolMixin, QeBaseRestartWorkChain):
 
         # Update the parameters based on the protocol inputs
         inputs = cls.get_protocol_inputs(protocol, overrides)
-        parameters = inputs[cls._inputs_namespace]["parameters"]["inputpp"]
+        parameters = inputs[cls._inputs_namespace]["parameters"]["INPUTPP"]
         metadata = inputs[cls._inputs_namespace]["metadata"]
 
         # Set projection
@@ -197,7 +197,7 @@ class Pw2wannier90BaseWorkChain(ProtocolMixin, QeBaseRestartWorkChain):
                 ):
                     parameters["atom_proj_frozen"] = list(external_projectors_froz)
 
-        parameters = {"inputpp": parameters}
+        parameters = {"INPUTPP": parameters}
 
         # If overrides are provided, they take precedence over default protocol
         if overrides:
@@ -253,7 +253,7 @@ class Pw2wannier90BaseWorkChain(ProtocolMixin, QeBaseRestartWorkChain):
         inputs = AttributeDict(
             self.exposed_inputs(Pw2wannier90Calculation, self._inputs_namespace)
         )
-        parameters = inputs["parameters"].get_dict().get("inputpp", {})
+        parameters = inputs["parameters"].get_dict().get("INPUTPP", {})
 
         scdm_proj = parameters.get("scdm_proj", False)
         scdm_entanglement = parameters.get("scdm_entanglement", None)
@@ -290,7 +290,7 @@ class Pw2wannier90BaseWorkChain(ProtocolMixin, QeBaseRestartWorkChain):
                 parameters["scdm_mu"] = mu_new
             if "scdm_sigma" not in parameters:
                 parameters["scdm_sigma"] = sigma_new
-            inputs["parameters"] = orm.Dict({"inputpp": parameters})
+            inputs["parameters"] = orm.Dict({"INPUTPP": parameters})
 
         return inputs
 

--- a/src/aiida_wannier90_workflows/workflows/protocols/base/projwfc.yaml
+++ b/src/aiida_wannier90_workflows/workflows/protocols/base/projwfc.yaml
@@ -3,7 +3,7 @@ default_inputs:
     projwfc:
         parameters:
             PROJWFC:
-                DeltaE: 0.2
+                deltae: 0.2
         metadata:
             options:
                 resources:

--- a/src/aiida_wannier90_workflows/workflows/protocols/base/pw2wannier90.yaml
+++ b/src/aiida_wannier90_workflows/workflows/protocols/base/pw2wannier90.yaml
@@ -8,7 +8,7 @@ default_inputs:
                 max_wallclock_seconds: 43200  # Twelve hours
                 withmpi: True
         parameters:
-            inputpp: {}
+            INPUTPP: {}
 default_protocol: moderate
 protocols:
     moderate:

--- a/src/aiida_wannier90_workflows/workflows/protocols/overrides/wannier90.yaml
+++ b/src/aiida_wannier90_workflows/workflows/protocols/overrides/wannier90.yaml
@@ -2,7 +2,7 @@ plot_wannier_functions:
     pw2wannier90:
         pw2wannier90:
             parameters:
-                inputpp:
+                INPUTPP:
                     write_unk: True
     wannier90:
         wannier90:

--- a/src/aiida_wannier90_workflows/workflows/split.py
+++ b/src/aiida_wannier90_workflows/workflows/split.py
@@ -266,8 +266,8 @@ class Wannier90SplitWorkChain(WorkChain):  # pylint: disable=too-many-public-met
         parameters = valcond_inputs["pw2wannier90"]["pw2wannier90"][
             "parameters"
         ].get_dict()
-        parameters["inputpp"]["wvfn_formatted"] = True
-        parameters["inputpp"]["spn_formatted"] = True
+        parameters["INPUTPP"]["wvfn_formatted"] = True
+        parameters["INPUTPP"]["spn_formatted"] = True
         valcond_inputs["pw2wannier90"]["pw2wannier90"]["parameters"] = orm.Dict(
             dict=parameters
         )

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -48,7 +48,7 @@ def validate_inputs(  # pylint: disable=unused-argument,inconsistent-return-stat
         "parameters"
     ].get_dict()
     auto_energy_windows = inputs["wannier90"].get("auto_energy_windows", False)
-    scdm_proj = pw2wannier_parameters["inputpp"].get("scdm_proj", False)
+    scdm_proj = pw2wannier_parameters["INPUTPP"].get("scdm_proj", False)
     if auto_energy_windows and scdm_proj:
         return "`auto_energy_windows` is incompatible with SCDM"
 
@@ -963,7 +963,7 @@ class Wannier90WorkChain(
             self.exposed_inputs(Pw2wannier90BaseWorkChain, namespace="pw2wannier90")
         )
         inputs = base_inputs["pw2wannier90"]
-        parameters = inputs.parameters.get_dict().get("inputpp", {})
+        parameters = inputs.parameters.get_dict().get("INPUTPP", {})
 
         scdm_proj = parameters.get("scdm_proj", False)
         scdm_entanglement = parameters.get("scdm_entanglement", None)
@@ -1044,7 +1044,7 @@ class Wannier90WorkChain(
 
         inputs = prepare_process_inputs(Pw2wannier90BaseWorkChain, inputs)
         parameters = inputs["pw2wannier90"]["parameters"].get_dict()
-        parameters["inputpp"].update({"spin_component": "up"})
+        parameters["INPUTPP"].update({"spin_component": "up"})
         inputs["pw2wannier90"]["parameters"] = orm.Dict(parameters)
         running = self.submit(Pw2wannier90BaseWorkChain, **inputs)
         self.report(f"launching {running.process_label}<{running.pk}>")
@@ -1059,7 +1059,7 @@ class Wannier90WorkChain(
 
         inputs = prepare_process_inputs(Pw2wannier90BaseWorkChain, inputs)
         parameters = inputs["pw2wannier90"]["parameters"].get_dict()
-        parameters["inputpp"].update({"spin_component": "down"})
+        parameters["INPUTPP"].update({"spin_component": "down"})
         inputs["pw2wannier90"]["parameters"] = orm.Dict(parameters)
         running = self.submit(Pw2wannier90BaseWorkChain, **inputs)
         self.report(f"launching {running.process_label}<{running.pk}>")
@@ -1349,7 +1349,7 @@ class Wannier90WorkChain(
         # If using external atomic projectors, disable sanity check
         p2w_params = self.ctx.workchain_pw2wannier90.inputs["pw2wannier90"][
             "parameters"
-        ].get_dict()["inputpp"]
+        ].get_dict()["INPUTPP"]
         atom_proj = p2w_params.get("atom_proj", False)
         atom_proj_ext = p2w_params.get("atom_proj_ext", False)
         if atom_proj and atom_proj_ext:
@@ -1469,7 +1469,7 @@ class Wannier90WorkChain(
         if "workchain_pw2wannier90_up" in self.ctx:
             p2w_params_up = self.ctx.workchain_pw2wannier90_up.inputs["pw2wannier90"][
                 "parameters"
-            ].get_dict()["inputpp"]
+            ].get_dict()["INPUTPP"]
             atom_proj = p2w_params_up.get("atom_proj", False)
             atom_proj_ext = p2w_params_up.get("atom_proj_ext", False)
             if atom_proj and atom_proj_ext:
@@ -1477,7 +1477,7 @@ class Wannier90WorkChain(
         if "workchain_pw2wannier90_down" in self.ctx:
             p2w_params_down = self.ctx.workchain_pw2wannier90_down.inputs[
                 "pw2wannier90"
-            ]["parameters"].get_dict()["inputpp"]
+            ]["parameters"].get_dict()["INPUTPP"]
             atom_proj = p2w_params_down.get("atom_proj", False)
             atom_proj_ext = p2w_params_down.get("atom_proj_ext", False)
             if atom_proj and atom_proj_ext:

--- a/tests/workflows/base/test_pw2wannier90.py
+++ b/tests/workflows/base/test_pw2wannier90.py
@@ -32,12 +32,12 @@ def test_prepare_inputs(
     from aiida.orm import Dict
 
     inputs = generate_inputs_pw2wannier90_base()
-    parameters = inputs["parameters"].get_dict()["inputpp"]
+    parameters = inputs["parameters"].get_dict()["INPUTPP"]
 
     # Test SCDM fitting is working
     parameters["scdm_proj"] = True
     parameters["scdm_entanglement"] = "erfc"
-    inputs["parameters"] = Dict({"inputpp": parameters})
+    inputs["parameters"] = Dict({"INPUTPP": parameters})
 
     inputs = {"pw2wannier90": inputs}
     inputs["bands"] = generate_bands_data()
@@ -48,7 +48,7 @@ def test_prepare_inputs(
 
     assert isinstance(inputs, AttributeDict)
 
-    parameters = inputs["parameters"].get_dict()["inputpp"]
+    parameters = inputs["parameters"].get_dict()["INPUTPP"]
     assert "scdm_mu" in parameters, parameters
     assert "scdm_sigma" in parameters, parameters
     assert abs(parameters["scdm_mu"] - 6.023033662603666) < 1e-5, parameters

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -142,7 +142,7 @@ def generate_inputs_pw2wannier90_base(
 
         inputs = {
             "code": fixture_code("quantumespresso.pw2wannier90"),
-            "parameters": orm.Dict({"inputpp": {}}),
+            "parameters": orm.Dict({"INPUTPP": {}}),
             "nnkp_file": orm.SinglefileData(file=nnkp_filepath).store(),
             "parent_folder": generate_remote_data(
                 fixture_localhost,
@@ -298,14 +298,14 @@ def generate_inputs_wannier90(generate_inputs_pw, fixture_code):
         nscf_pw_inputs["parameters"] = Dict(params)
         nscf = {"pw": nscf_pw_inputs, "kpoints": kpoints}
 
-        projwfc_params = {"projwfc": {"deltae": 0.01}}
+        projwfc_params = {"PROJWFC": {"deltae": 0.01}}
         projwfc = {
             "code": fixture_code("quantumespresso.projwfc"),
             "parameters": Dict(projwfc_params),
             "metadata": {"options": get_default_options()},
         }
         pw2wan_params = {
-            "inputpp": {
+            "INPUTPP": {
                 "scdm_proj": True,
                 "scdm_entanglement": "erfc",
             }

--- a/tests/workflows/protocols/base/test_projwfc/test_default.yml
+++ b/tests/workflows/protocols/base/test_projwfc/test_default.yml
@@ -9,4 +9,4 @@ projwfc:
       withmpi: true
   parameters:
     PROJWFC:
-      DeltaE: 0.2
+      deltae: 0.2

--- a/tests/workflows/protocols/base/test_projwfc/test_overrides.yml
+++ b/tests/workflows/protocols/base/test_projwfc/test_overrides.yml
@@ -9,4 +9,4 @@ projwfc:
       withmpi: false
   parameters:
     PROJWFC:
-      DeltaE: 0.2
+      deltae: 0.2

--- a/tests/workflows/protocols/base/test_pw2wannier90.py
+++ b/tests/workflows/protocols/base/test_pw2wannier90.py
@@ -38,7 +38,7 @@ def test_overrides(fixture_code, data_regression, serialize_builder):
     """Test ``Pw2wannier90BaseWorkChain.get_builder_from_protocol`` for the ``overrides`` input."""
     code = fixture_code("quantumespresso.pw2wannier90")
 
-    overrides = {"pw2wannier90": {"parameters": {"inputpp": {"fake_input": "fake"}}}}
+    overrides = {"pw2wannier90": {"parameters": {"INPUTPP": {"fake_input": "fake"}}}}
     builder = Pw2wannier90BaseWorkChain.get_builder_from_protocol(
         code=code, overrides=overrides
     )
@@ -61,7 +61,7 @@ def test_electronic_type(fixture_code, electronic_type):
         projection_type=WannierProjectionType.SCDM,
     )
 
-    parameters = builder["pw2wannier90"]["parameters"].get_dict()["inputpp"]
+    parameters = builder["pw2wannier90"]["parameters"].get_dict()["INPUTPP"]
     assert parameters["scdm_entanglement"] == electronic_type[1]
 
 
@@ -80,7 +80,7 @@ def test_projection_type(fixture_code, projection_type):
         code=code, projection_type=projection_type[0]
     )
 
-    parameters = builder["pw2wannier90"]["parameters"].get_dict()["inputpp"]
+    parameters = builder["pw2wannier90"]["parameters"].get_dict()["INPUTPP"]
     assert projection_type[1] in parameters
     assert parameters[projection_type[1]]
 
@@ -96,5 +96,5 @@ def test_exclude_projectors(fixture_code):
         exclude_projectors=exclude_projectors,
     )
 
-    parameters = builder["pw2wannier90"]["parameters"].get_dict()["inputpp"]
+    parameters = builder["pw2wannier90"]["parameters"].get_dict()["INPUTPP"]
     assert parameters["atom_proj_exclude"] == exclude_projectors

--- a/tests/workflows/protocols/base/test_pw2wannier90/test_default.yml
+++ b/tests/workflows/protocols/base/test_pw2wannier90/test_default.yml
@@ -8,5 +8,5 @@ pw2wannier90:
         num_machines: 1
       withmpi: true
   parameters:
-    inputpp:
+    INPUTPP:
       atom_proj: true

--- a/tests/workflows/protocols/base/test_pw2wannier90/test_overrides.yml
+++ b/tests/workflows/protocols/base/test_pw2wannier90/test_overrides.yml
@@ -8,6 +8,6 @@ pw2wannier90:
         num_machines: 1
       withmpi: true
   parameters:
-    inputpp:
+    INPUTPP:
       atom_proj: true
       fake_input: fake

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_BaTiO3_.yml
@@ -49,7 +49,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 1

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_GaAs_.yml
@@ -48,7 +48,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 5

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_H2O_.yml
@@ -48,7 +48,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_Si_.yml
@@ -47,7 +47,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_bands/test_scdm_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_bands/test_scdm_BaTiO3_.yml
@@ -50,7 +50,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -61,7 +61,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_bands/test_scdm_GaAs_.yml
+++ b/tests/workflows/protocols/test_bands/test_scdm_GaAs_.yml
@@ -49,7 +49,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -60,7 +60,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_bands/test_scdm_H2O_.yml
+++ b/tests/workflows/protocols/test_bands/test_scdm_H2O_.yml
@@ -49,7 +49,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -60,7 +60,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_bands/test_scdm_Si_.yml
+++ b/tests/workflows/protocols/test_bands/test_scdm_Si_.yml
@@ -48,7 +48,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -59,7 +59,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_BaTiO3_.yml
@@ -52,7 +52,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -63,7 +63,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_GaAs_.yml
@@ -51,7 +51,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -62,7 +62,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_H2O_.yml
@@ -51,7 +51,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -62,7 +62,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_bands/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_bands/test_spin_orbit_Si_.yml
@@ -50,7 +50,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -61,7 +61,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_BaTiO3_.yml
@@ -18,7 +18,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 1

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_GaAs_.yml
@@ -18,7 +18,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 5

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_H2O_.yml
@@ -18,7 +18,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_Si_.yml
@@ -18,7 +18,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_open_grid/test_scdm_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_scdm_BaTiO3_.yml
@@ -19,7 +19,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -30,7 +30,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_open_grid/test_scdm_GaAs_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_scdm_GaAs_.yml
@@ -19,7 +19,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -30,7 +30,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_open_grid/test_scdm_H2O_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_scdm_H2O_.yml
@@ -19,7 +19,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -30,7 +30,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_open_grid/test_scdm_Si_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_scdm_Si_.yml
@@ -19,7 +19,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -30,7 +30,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_BaTiO3_.yml
@@ -50,7 +50,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 1

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_GaAs_.yml
@@ -49,7 +49,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 5

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_H2O_.yml
@@ -49,7 +49,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_Si_.yml
@@ -48,7 +48,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
@@ -52,7 +52,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 1

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
@@ -51,7 +51,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 1

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
@@ -51,7 +51,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
@@ -50,7 +50,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_protocols.py
+++ b/tests/workflows/protocols/test_protocols.py
@@ -25,7 +25,7 @@ from aiida_wannier90_workflows.workflows.wannier90 import Wannier90WorkChain
         {"projwfc": {"projwfc": {"metadata": {"options": {"account": "infinite"}}}}},
         {
             "pw2wannier90": {
-                "pw2wannier90": {"parameters": {"inputpp": {"scdm_proj": False}}}
+                "pw2wannier90": {"parameters": {"INPUTPP": {"scdm_proj": False}}}
             }
         },
         {"wannier90": {"auto_energy_windows_threshold": 0.01}},

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides2_Wannier90BandsWorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides2_Wannier90BandsWorkChain_.yml
@@ -9,4 +9,4 @@ projwfc:
       withmpi: true
   parameters:
     PROJWFC:
-      DeltaE: 0.2
+      deltae: 0.2

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides2_Wannier90OpenGridWorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides2_Wannier90OpenGridWorkChain_.yml
@@ -9,4 +9,4 @@ projwfc:
       withmpi: true
   parameters:
     PROJWFC:
-      DeltaE: 0.2
+      deltae: 0.2

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides2_Wannier90WorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides2_Wannier90WorkChain_.yml
@@ -9,4 +9,4 @@ projwfc:
       withmpi: true
   parameters:
     PROJWFC:
-      DeltaE: 0.2
+      deltae: 0.2

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90BandsWorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90BandsWorkChain_.yml
@@ -7,6 +7,6 @@ pw2wannier90:
         num_machines: 1
       withmpi: true
   parameters:
-    inputpp:
+    INPUTPP:
       scdm_entanglement: erfc
       scdm_proj: false

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90OpenGridWorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90OpenGridWorkChain_.yml
@@ -7,6 +7,6 @@ pw2wannier90:
         num_machines: 1
       withmpi: true
   parameters:
-    inputpp:
+    INPUTPP:
       scdm_entanglement: erfc
       scdm_proj: false

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90OptimizeWorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90OptimizeWorkChain_.yml
@@ -7,6 +7,6 @@ pw2wannier90:
         num_machines: 1
       withmpi: true
   parameters:
-    inputpp:
+    INPUTPP:
       atom_proj: true
       scdm_proj: false

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90WorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides3_Wannier90WorkChain_.yml
@@ -7,6 +7,6 @@ pw2wannier90:
         num_machines: 1
       withmpi: true
   parameters:
-    inputpp:
+    INPUTPP:
       scdm_entanglement: erfc
       scdm_proj: false

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_BaTiO3_.yml
@@ -49,7 +49,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 1

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_GaAs_.yml
@@ -48,7 +48,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
         atom_proj_exclude:
         - 5

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_H2O_.yml
@@ -48,7 +48,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_Si_.yml
@@ -47,7 +47,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         atom_proj: true
 scf:
   kpoints_distance: 0.2

--- a/tests/workflows/protocols/test_wannier90/test_force_parity.yml
+++ b/tests/workflows/protocols/test_wannier90/test_force_parity.yml
@@ -48,7 +48,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -59,7 +59,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_scdm_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_scdm_BaTiO3_.yml
@@ -50,7 +50,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -61,7 +61,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_scdm_GaAs_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_scdm_GaAs_.yml
@@ -49,7 +49,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -60,7 +60,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_scdm_H2O_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_scdm_H2O_.yml
@@ -49,7 +49,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -60,7 +60,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_scdm_Si_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_scdm_Si_.yml
@@ -48,7 +48,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -59,7 +59,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_BaTiO3_.yml
@@ -52,7 +52,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -63,7 +63,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_GaAs_.yml
@@ -51,7 +51,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -62,7 +62,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_H2O_.yml
@@ -51,7 +51,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -62,7 +62,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:

--- a/tests/workflows/protocols/test_wannier90/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_spin_orbit_Si_.yml
@@ -50,7 +50,7 @@ projwfc:
         withmpi: true
     parameters:
       PROJWFC:
-        DeltaE: 0.2
+        deltae: 0.2
 pw2wannier90:
   pw2wannier90:
     code: test.quantumespresso.pw2wannier90@localhost
@@ -61,7 +61,7 @@ pw2wannier90:
           num_machines: 1
         withmpi: true
     parameters:
-      inputpp:
+      INPUTPP:
         scdm_entanglement: erfc
         scdm_proj: true
 scf:


### PR DESCRIPTION
## Problem

`main` fails CI becasue `aiida-quantumespresso 4.15` introduced a consistent casing convention for CalcJob `parameters` input: namelist keys must be UPPERCASE and parameter keys lowercase, and unstored `Dict` nodes are auto-corrected in place with a warning. This surfaced two failure modes in this package.
- First, real `KeyError`s at runtime — code that read `parameters.get_dict()["inputpp"]` crashed because the validator had already normalized the node to `INPUTPP`
- Second, pytest-regressions snapshot mismatches across every protocol builder test — obtained `INPUTPP`/`deltae` vs stored `inputpp`/`DeltaE`

## Change
Adapt the package to emit and read the canonical casing throughout.
- Protocol YAMLs now use `INPUTPP` (base `pw2wannier90.yaml`, `overrides/wannier90.yaml`) and lowercase `deltae` (base `projwfc.yaml`).
- The source reads/writes the pw2wannier90 QE namelist as `INPUTPP` everywhere
- Test code and fixtures use the `INPUTPP`/`PROJWFC` namelist keys so that shared unstored fixture `Dict` nodes are not mutated out from under the subsequent reads
- The affected pytest-regressions snapshots are regenerated.

## Testing

`uv pip install -e ".[tests]" aiida-quantumespresso==4.15.0` in an isolated Python 3.11 venv.
- Before the change: **59 failed, 102 passed**.
- After the change (`pytest tests/`): **161 passed, 0 failed**.

The full suite was additionally run against `aiida-quantumespresso 5.0.0` (which hard-enforces the convention): also **161 passed, 0 failed**.

Snapshots were regenerated with `pytest --force-regen` and the full suite reruns clean.

Fixes #90 