### PR TITLE
Get pseudos without requiring recommended cutoffs

### DIFF
--- a/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
+++ b/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
@@ -7,34 +7,67 @@ from aiida.common import exceptions
 from aiida.plugins import DataFactory, GroupFactory
 
 PseudoPotentialData = DataFactory("pseudo")
+PseudoPotentialFamily = GroupFactory("pseudo.family")
 SsspFamily = GroupFactory("pseudo.family.sssp")
 PseudoDojoFamily = GroupFactory("pseudo.family.pseudo_dojo")
 CutoffsPseudoPotentialFamily = GroupFactory("pseudo.family.cutoffs")
 
 
+def _load_pseudo_family(
+    label: str, pseudo_set: ty.Tuple[type, ...] = (PseudoPotentialFamily,)
+):
+    """Return the stored pseudopotential family with the given label.
+
+    :param pseudo_set: the family classes to search. The default accepts every
+        ``aiida-pseudo`` family; pass a narrower set when the caller needs a
+        capability only some families have.
+    :raises ValueError: no family in ``pseudo_set`` carries that label.
+    """
+    try:
+        return orm.QueryBuilder().append(pseudo_set, filters={"label": label}).one()[0]
+    except exceptions.NotExistent as exception:
+        raise ValueError(
+            f"required pseudo family `{label}` is not installed. Please use `aiida-pseudo install` to"
+            "install it."
+        ) from exception
+
+
+def get_pseudos(
+    pseudo_family: str, structure: orm.StructureData
+) -> ty.Mapping[str, PseudoPotentialData]:
+    """Get the pseudo potential of each kind of a structure, from a pseudo family.
+
+    Any ``aiida-pseudo`` family serves, including one built by the user with
+    ``aiida-pseudo install family``: no recommended cutoffs are needed.
+
+    :param pseudo_family: label of the family to take the pseudos from.
+    :param structure: the structure whose kinds are to be covered.
+    :raises ValueError: the family is not installed, or does not cover every
+        kind of the structure.
+    """
+    return _load_pseudo_family(pseudo_family).get_pseudos(structure=structure)
+
+
 def get_pseudo_and_cutoff(
     pseudo_family: str, structure: orm.StructureData
 ) -> ty.Tuple[ty.Mapping[str, PseudoPotentialData], float, float]:
-    """Get pseudo potential and cutoffs of a given pseudo family and structure.
+    """Get the pseudo potentials and the recommended cutoffs of a pseudo family.
 
-    :param pseudo_family: [description]
-    :param structure: [description]
-    :raises ValueError: [description]
-    :raises ValueError: [description]
-    :return: [description]
+    Only families that recommend cutoffs qualify, i.e. SSSP, PseudoDojo and any
+    family with a cutoff stringency defined. Use :func:`get_pseudos` when the
+    cutoffs are not needed.
+
+    :param pseudo_family: label of the family to take the pseudos from.
+    :param structure: the structure whose kinds are to be covered.
+    :raises ValueError: the family is not installed among those that recommend
+        cutoffs.
+    :raises ValueError: the family recommends no cutoffs for this structure.
+    :return: the pseudos per kind, the wave-function cutoff and the charge
+        density cutoff, both in Ry.
     """
-    try:
-        pseudo_set = (PseudoDojoFamily, SsspFamily, CutoffsPseudoPotentialFamily)
-        pseudo_family = (
-            orm.QueryBuilder()
-            .append(pseudo_set, filters={"label": pseudo_family})
-            .one()[0]
-        )
-    except exceptions.NotExistent as exception:
-        raise ValueError(
-            f"required pseudo family `{pseudo_family}` is not installed. Please use `aiida-pseudo install` to"
-            "install it."
-        ) from exception
+    pseudo_family = _load_pseudo_family(
+        pseudo_family, (PseudoDojoFamily, SsspFamily, CutoffsPseudoPotentialFamily)
+    )
 
     try:
         cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(

--- a/src/aiida_wannier90_workflows/workflows/base/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/wannier90.py
@@ -271,8 +271,8 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         from aiida_wannier90_workflows.utils.pseudo import (
             get_number_of_projections,
             get_number_of_projections_ext,
-            get_pseudo_and_cutoff,
             get_pseudo_orbitals,
+            get_pseudos,
             get_semicore_list,
             get_semicore_list_ext,
             get_wannier_number_of_bands,
@@ -323,7 +323,7 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         if pseudo_family is None:
             pseudo_family = meta_parameters["pseudo_family"]
-        pseudos, _, _ = get_pseudo_and_cutoff(pseudo_family, structure)
+        pseudos = get_pseudos(pseudo_family, structure)
 
         if external_projectors is not None:
             if projection_type in [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,41 @@ def pseudos(aiida_profile, generate_upf_data, generate_upf_data_soc):
 
 
 @pytest.fixture(scope="session")
+def cutoffs_family_without_stringency(
+    pseudos, generate_upf_data
+):  # pylint: disable=unused-argument
+    """Create a cutoffs family with no stringency, so it recommends no cutoffs.
+
+    The shape a user gets after grouping pseudos of their own into a
+    ``CutoffsPseudoPotentialFamily`` without calling ``set_cutoffs``. Ordered
+    after ``pseudos``, which resets the profile.
+    """
+    from aiida.plugins import GroupFactory
+
+    family = GroupFactory("pseudo.family.cutoffs")(label="NoStringency/1.0")
+    family.store()
+    family.add_nodes([generate_upf_data("Si")])
+
+    return family
+
+
+@pytest.fixture(scope="session")
+def plain_pseudo_family(pseudos, generate_upf_data):  # pylint: disable=unused-argument
+    """Create a plain family, the shape ``aiida-pseudo install family`` produces.
+
+    Cutoffs are not even representable on this family class. Ordered after
+    ``pseudos``, which resets the profile.
+    """
+    from aiida.plugins import GroupFactory
+
+    family = GroupFactory("pseudo.family")(label="MyPseudos/local")
+    family.store()
+    family.add_nodes([generate_upf_data("Si")])
+
+    return family
+
+
+@pytest.fixture(scope="session")
 def generate_upf_data(filepath_fixtures):
     """Return a `UpfData` instance for the given element a file for which should exist in `tests/fixtures/pseudos`."""
 

--- a/tests/utils/test_pseudo.py
+++ b/tests/utils/test_pseudo.py
@@ -1,0 +1,66 @@
+"""Tests for the :py:mod:`~aiida_wannier90_workflows.utils.pseudo` module."""
+
+import pytest
+
+from aiida_wannier90_workflows.utils.pseudo import get_pseudo_and_cutoff, get_pseudos
+
+
+def test_get_pseudos_cutoffs_family_without_stringency(
+    cutoffs_family_without_stringency, generate_structure
+):
+    """A family that recommends no cutoffs still provides its pseudos."""
+    pseudos = get_pseudos(
+        cutoffs_family_without_stringency.label, generate_structure("Si")
+    )
+
+    assert sorted(pseudos) == ["Si"]
+
+
+def test_get_pseudos_plain_family(plain_pseudo_family, generate_structure):
+    """A family that cannot carry cutoffs at all still provides its pseudos."""
+    pseudos = get_pseudos(plain_pseudo_family.label, generate_structure("Si"))
+
+    assert sorted(pseudos) == ["Si"]
+
+
+def test_get_pseudos_family_with_cutoffs(pseudos, generate_structure):
+    """A family that does recommend cutoffs is served by the same entry point."""
+    sssp, _ = pseudos
+
+    assert sorted(get_pseudos(sssp.label, generate_structure("Si"))) == ["Si"]
+
+
+def test_get_pseudos_family_not_installed(generate_structure):
+    """An unknown label names itself in the error."""
+    with pytest.raises(ValueError, match="`NotAFamily/1.0` is not installed"):
+        get_pseudos("NotAFamily/1.0", generate_structure("Si"))
+
+
+def test_get_pseudo_and_cutoff_returns_cutoffs(pseudos, generate_structure):
+    """The cutoffs of a family that has them are unchanged."""
+    sssp, _ = pseudos
+
+    found, cutoff_wfc, cutoff_rho = get_pseudo_and_cutoff(
+        sssp.label, generate_structure("Si")
+    )
+
+    assert sorted(found) == ["Si"]
+    assert (cutoff_wfc, cutoff_rho) == (30.0, 240.0)
+
+
+def test_get_pseudo_and_cutoff_requires_cutoffs(
+    cutoffs_family_without_stringency, generate_structure
+):
+    """Asking for cutoffs a family does not have still raises."""
+    with pytest.raises(ValueError, match="failed to obtain recommended cutoffs"):
+        get_pseudo_and_cutoff(
+            cutoffs_family_without_stringency.label, generate_structure("Si")
+        )
+
+
+def test_get_pseudo_and_cutoff_rejects_plain_family(
+    plain_pseudo_family, generate_structure
+):
+    """A family that cannot carry cutoffs is not a candidate for this function."""
+    with pytest.raises(ValueError, match="`MyPseudos/local` is not installed"):
+        get_pseudo_and_cutoff(plain_pseudo_family.label, generate_structure("Si"))

--- a/tests/workflows/protocols/base/test_wannier90.py
+++ b/tests/workflows/protocols/base/test_wannier90.py
@@ -210,3 +210,33 @@ def test_metadata_overrides(
     )
 
     data_regression.check(serialize_builder(builder))
+
+
+@pytest.mark.parametrize(
+    "family_fixture", ("cutoffs_family_without_stringency", "plain_pseudo_family")
+)
+def test_pseudo_family_without_cutoffs(
+    fixture_code, generate_structure, request, family_fixture
+):
+    """A pseudo family that recommends no cutoffs builds the same inputs.
+
+    This builder counts bands and projections from the pseudos and never uses
+    the cutoffs, so a family that has none must serve it as well as one that
+    does.
+    """
+    code = fixture_code("wannier90.wannier90")
+    structure = generate_structure("Si")
+    family = request.getfixturevalue(family_fixture)
+
+    builder = Wannier90BaseWorkChain.get_builder_from_protocol(
+        code, structure=structure, pseudo_family=family.label
+    )
+    reference = Wannier90BaseWorkChain.get_builder_from_protocol(
+        code, structure=structure
+    )
+
+    assert isinstance(builder, ProcessBuilder)
+    assert (
+        builder.wannier90.parameters.get_dict()
+        == reference.wannier90.parameters.get_dict()
+    )


### PR DESCRIPTION
### Summary

This PR enables custom pseudo families to be used when building workflows from protocols.

### Problem

`Wannier90BaseWorkChain.get_builder_from_protocol` refuses any pseudopotential family that recommends no cutoffs, even though the builder never uses cutoffs. THis means that one can't use...

- a `CutoffsPseudoPotentialFamily` whose stringencies were never set, refused with `failed to obtain recommended cutoffs for pseudo family ...: no default stringency has been defined`;
- a plain `PseudoPotentialFamily` (the shape `aiida-pseudo install family` produces) refused with `required pseudo family ... is not installed` because that class is not among those the lookup searches.

### Cause

Both come from one line
```
pseudos, _, _ = get_pseudo_and_cutoff(pseudo_family, structure)
```
which asks for cutoffs and then discards them; the pseudos are wanted only to count bands and projections. That is the only call to `get_pseudo_and_cutoff` in the package.

The practical cost is that pseudopotentials outside `aiida-pseudo`'s catalogue cannot be Wannierized through the protocols at all.

### Changes

- Add `get_pseudos(pseudo_family, structure)`, which resolves a family by label and returns its pseudos per kind. It accepts any `aiida-pseudo` family class and asks for no cutoffs.
- Take the Wannier90 protocol builder's pseudos from `get_pseudos`. Which families are accepted changes; what is built from them does not.
- Leave `get_pseudo_and_cutoff` as it was for external callers: same signature and return, and it still searches only SSSP, PseudoDojo and cutoffs families, because those are the ones that can recommend cutoffs.

With this, a user's own pseudos reach the Wannier90 builder:

```console
$ aiida-pseudo install family ./my_pseudos.tar.gz MyPseudos/local
```

```python
builder = Wannier90BandsWorkChain.get_builder_from_protocol(
    codes=codes,
    structure=structure,
    pseudo_family="MyPseudos/local",
)
```

The pw.x sub-workchains still need `ecutwfc` and `ecutrho` supplied through `overrides`, since `PwBaseWorkChain` really does use the cutoffs. A cutoff-less family with no such overrides now fails there, naming the cutoffs, instead of failing earlier in the Wannier90 builder that had no use for them.

### Testing

- Two builder tests, over both refused shapes, assert that `Wannier90BaseWorkChain.get_builder_from_protocol` produces wannier90 parameters equal to those built from a family that does recommend cutoffs. Equality is the point: it discriminates a builder that merely stops raising from one that builds the same inputs. Both fail on `main` — one with the stringency error, one with "is not installed" — while the other nineteen tests in that file pass unchanged.
- Unit tests cover `get_pseudos` over the two refused shapes, an SSSP family as control, and an unknown label.
- Two tests pin `get_pseudo_and_cutoff`'s unchanged contract: it still returns SSSP's cutoffs, and it still refuses a family that cannot supply them.
- The full suite shows the same set of failures before and after the change, with nine more passing tests.

Fixtures for the two family shapes are added to `tests/conftest.py`, next to the existing `pseudos` fixture and built from the same synthetic UPF streams, so the pseudos differ from the SSSP family's only in which group they belong to.

### Related
#95 will fix the failing test suite

#94 removes the other wall a custom pseudo family meets: `get_pseudo_orbitals` resolves pseudopotentials by md5 against the bundled semicore tables, so anything outside the curated families fails there too. The two are independent — this one is the cutoff lookup, that one the orbital lookup — and a hand-built family needs both to get through the protocols.