### PR TITLE
Pass `ctx` to parent validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "aiida-core>=2.0,<3",
     "aiida-pseudo>=0.6",
     "aiida-quantumespresso>=4.4",
-    "aiida-wannier90>=2.2",
+    "aiida-wannier90 @ git+https://github.com/aiidateam/aiida-wannier90.git@v2.2.0",
     "click>=8.0",
     "colorama"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.9"
 dependencies = [
     "aiida-core>=2.0,<3",
     "aiida-pseudo>=0.6",
-    "aiida-quantumespresso>=4.4",
+    "aiida-quantumespresso>=4.4,<5",
     "aiida-wannier90 @ git+https://github.com/aiidateam/aiida-wannier90.git@v2.2.0",
     "click>=8.0",
     "colorama"

--- a/src/aiida_wannier90_workflows/workflows/bands.py
+++ b/src/aiida_wannier90_workflows/workflows/bands.py
@@ -20,7 +20,7 @@ def validate_inputs(  # pylint: disable=unused-argument,inconsistent-return-stat
     from .open_grid import validate_inputs as parent_validate_inputs
 
     # Call parent validator
-    result = parent_validate_inputs(inputs)
+    result = parent_validate_inputs(inputs, ctx)
     if result is not None:
         return result
 

--- a/src/aiida_wannier90_workflows/workflows/open_grid.py
+++ b/src/aiida_wannier90_workflows/workflows/open_grid.py
@@ -23,7 +23,7 @@ def validate_inputs(  # pylint: disable=unused-argument,inconsistent-return-stat
     from .wannier90 import validate_inputs as parent_validate_inputs
 
     # Call parent validator
-    result = parent_validate_inputs(inputs)
+    result = parent_validate_inputs(inputs, ctx)
 
     if result is not None:
         return result

--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -26,7 +26,7 @@ def validate_inputs(inputs, ctx=None):  # pylint: disable=unused-argument
     from .bands import validate_inputs as parent_validate_inputs
 
     # Call parent validator
-    result = parent_validate_inputs(inputs)
+    result = parent_validate_inputs(inputs, ctx)
     if result is not None:
         return result
 
@@ -85,9 +85,7 @@ def validate_inputs(inputs, ctx=None):  # pylint: disable=unused-argument
 
 
 # pylint: disable=too-many-lines
-class Wannier90OptimizeWorkChain(
-    Wannier90BandsWorkChain
-):  # pylint: disable=too-many-public-methods
+class Wannier90OptimizeWorkChain(Wannier90BandsWorkChain):  # pylint: disable=too-many-public-methods
     """Workchain to optimize dis_proj_min/max for projectability disentanglement."""
 
     # The following keys are for wannier90.x plotting, i.e. they can be restarted from

--- a/src/aiida_wannier90_workflows/workflows/projwfcbands.py
+++ b/src/aiida_wannier90_workflows/workflows/projwfcbands.py
@@ -25,7 +25,7 @@ def validate_inputs(  # pylint: disable=unused-argument,inconsistent-return-stat
     )
 
     # Call parent validator
-    result = parent_validate_inputs(inputs)
+    result = parent_validate_inputs(inputs, ctx)
     if result is not None:
         return result
 


### PR DESCRIPTION
@mbercx broke aiida-quantumespresso API here - https://github.com/aiidateam/aiida-quantumespresso/commit/7a7899f07c19bb97f26059410872fd77d08454b9#r195782142, which unfortunately broke this code w.r.t aiida-quantumespresso >=4.15 🥲

Effectively, an unused optional argument was made required. This PR passes along `ctx` to be ignored downstream.

As a by-product of the recent PyPI issues with the AiiDA Wannier90 ecosystem, this PR also pins the installation of aiida-wannier90 to its GitHub repo.