### PR TITLE
👌 Only require `pw.x` in `get_builder_from_protocol` when it's actually needed

### DIFF
--- a/src/aiida_wannier90_workflows/utils/workflows/builder/submit.py
+++ b/src/aiida_wannier90_workflows/utils/workflows/builder/submit.py
@@ -52,16 +52,20 @@ def submit_builder(  # pylint: disable=inconsistent-return-statements
 
 
 def check_codes(
-    codes: ty.Mapping[str, ty.Union[str, int, orm.Code]]
+    codes: ty.Mapping[str, ty.Union[str, int, orm.Code]],
+    required_codes: ty.Sequence[str] = ("pw", "pw2wannier90", "wannier90"),
 ) -> ty.Mapping[str, orm.Code]:
     """Check and load pw.x, pw2wannier90.x, wannier90.x, projwfc.x, open_grid.x codes for Wannier workchain.
 
     :param codes: [description]
     :type codes: dict
+    :param required_codes: the keys that must be present in ``codes``. Callers that do not
+    populate every input namespace pass a smaller set, e.g. a builder that skips the scf
+    and nscf namespaces does not need `pw`.
+    :type required_codes: ty.Sequence[str]
     :raises ValueError: [description]
     :raises ValueError: [description]
     """
-    required_codes = ("pw", "pw2wannier90", "wannier90")
     optional_codes = ("projwfc", "open_grid")
 
     if not isinstance(codes, ty.Mapping):

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -633,6 +633,11 @@ class Wannier90WorkChain(
             # Remove workchain excluded inputs
             projwfc_builder.pop("clean_workdir", None)
             builder.projwfc = projwfc_builder._inputs(prune=True)
+            if nscf_parent_folder is not None:
+                # ``setup`` takes this as the starting folder, ahead of pw2wannier90,
+                # when it finds no scf/nscf namespace but does find a projwfc one, and
+                # ``run_projwfc`` passes it on to the calculation.
+                builder.projwfc["projwfc"]["parent_folder"] = nscf_parent_folder
 
         # Prepare pw2wannier90 builder
         exclude_projectors = None

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -369,6 +369,7 @@ class Wannier90WorkChain(
         """
         from aiida_wannier90_workflows.utils.pseudo import (
             get_frozen_list_ext,
+            get_pseudo_and_cutoff,
             get_pseudo_orbitals,
             get_semicore_list,
             get_semicore_list_ext,
@@ -648,18 +649,15 @@ class Wannier90WorkChain(
                 spin_non_collinear=spin_non_collinear,
             )
         if exclude_semicore:
-            # The semicore states are read off the pseudopotentials, which reach the
-            # builder only through a pw namespace.
+            # The semicore states are read off the pseudopotentials. Take them from a pw
+            # namespace when one was assembled; otherwise ``pseudo_family``, resolved
+            # above, and the structure determine them on their own.
             if run_scf:
                 pseudos = builder["scf"]["pw"]["pseudos"]
             elif run_nscf:
                 pseudos = builder["nscf"]["pw"]["pseudos"]
             else:
-                raise ValueError(
-                    "Cannot determine the semicore states when `nscf_parent_folder` "
-                    "leaves no pw namespace: pass `exclude_semicore=False` and set "
-                    "`exclude_bands` in the `wannier90` overrides instead."
-                )
+                pseudos, _, _ = get_pseudo_and_cutoff(pseudo_family, structure)
             pseudo_orbitals = get_pseudo_orbitals(pseudos)
             if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL:
                 exclude_projectors = get_semicore_list_ext(

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -305,6 +305,8 @@ class Wannier90WorkChain(
         retrieve_matrices: bool = False,
         compute_fermi_surface: bool = False,
         fermi_surface_kpoint_distance: float = 0.04,
+        scf_parent_folder: orm.RemoteData = None,
+        nscf_parent_folder: orm.RemoteData = None,
         print_summary: bool = True,
         summary: dict = None,
     ) -> ProcessBuilder:
@@ -348,6 +350,14 @@ class Wannier90WorkChain(
         :param retrieve_matrices: if True retrieve amn/mmn/eig/chk/spin files.
         :param compute_fermi_surface: if True compute the Fermi surface.
         :param fermi_surface_kpoint_distance: the distance between kpoints for the Fermi surface calculation.
+        :param scf_parent_folder: the remote folder of an scf run performed elsewhere. The
+        scf namespace is left unpopulated and the folder is set as the nscf `parent_folder`,
+        so the returned builder starts at the nscf step.
+        :param nscf_parent_folder: the remote folder of an nscf run performed elsewhere. Both
+        the scf and nscf namespaces are left unpopulated and the folder is set as the
+        pw2wannier90 `parent_folder`, so the returned builder starts at the wannier90 step.
+        No pw.x calculation remains, so `pw` may then be omitted from `codes`.
+        Mutually exclusive with `scf_parent_folder`.
         :param print_summary: if True print a summary of key input parameters
         :param summary: A dict containing key input parameters and can be printed out
         when the `get_builder_from_protocol` returns, to let user have a quick check of the
@@ -369,7 +379,22 @@ class Wannier90WorkChain(
         from aiida_wannier90_workflows.utils.workflows.builder.submit import check_codes
 
         # Check function arguments
-        codes = check_codes(codes)
+        if scf_parent_folder is not None and nscf_parent_folder is not None:
+            raise ValueError(
+                "`scf_parent_folder` and `nscf_parent_folder` are mutually exclusive: "
+                "pass `nscf_parent_folder` to start from the wannier90 step, or "
+                "`scf_parent_folder` to start from the nscf step."
+            )
+        # An nscf parent removes both pw steps; an scf parent removes only the scf one.
+        # Reusing an scf parent while skipping the nscf is not offered: wannierisation
+        # needs the nscf wavefunctions on the wannier90 k-mesh.
+        run_scf = scf_parent_folder is None and nscf_parent_folder is None
+        run_nscf = nscf_parent_folder is None
+
+        required_codes = ["pw2wannier90", "wannier90"]
+        if run_scf or run_nscf:
+            required_codes.insert(0, "pw")
+        codes = check_codes(codes, required_codes=required_codes)
         type_check(electronic_type, ElectronicType)
         type_check(spin_type, SpinType)
         type_check(projection_type, WannierProjectionType)
@@ -533,55 +558,61 @@ class Wannier90WorkChain(
         builder.wannier90 = wannier_builder._inputs(prune=True)
 
         # Prepare SCF builder
-        scf_overrides = inputs.get("scf", {})
-        scf_overrides["pseudo_family"] = pseudo_family
-        scf_builder = PwBaseWorkChain.get_builder_from_protocol(
-            code=codes["pw"],
-            structure=structure,
-            protocol=protocol,
-            overrides=scf_overrides,
-            electronic_type=electronic_type,
-            spin_type=pw_spin_type,
-            initial_magnetic_moments=initial_magnetic_moments,
-        )
-        # Remove workchain excluded inputs
-        scf_builder["pw"].pop("structure", None)
-        scf_builder.pop("clean_workdir", None)
-        builder.scf = scf_builder._inputs(prune=True)
+        if run_scf:
+            scf_overrides = inputs.get("scf", {})
+            scf_overrides["pseudo_family"] = pseudo_family
+            scf_builder = PwBaseWorkChain.get_builder_from_protocol(
+                code=codes["pw"],
+                structure=structure,
+                protocol=protocol,
+                overrides=scf_overrides,
+                electronic_type=electronic_type,
+                spin_type=pw_spin_type,
+                initial_magnetic_moments=initial_magnetic_moments,
+            )
+            # Remove workchain excluded inputs
+            scf_builder["pw"].pop("structure", None)
+            scf_builder.pop("clean_workdir", None)
+            builder.scf = scf_builder._inputs(prune=True)
 
         # Prepare NSCF builder
-        nscf_overrides = inputs.get("nscf", {})
-        nscf_overrides["pseudo_family"] = pseudo_family
+        if run_nscf:
+            nscf_overrides = inputs.get("nscf", {})
+            nscf_overrides["pseudo_family"] = pseudo_family
 
-        num_bands = wannier_builder["wannier90"]["parameters"]["num_bands"]
-        exclude_bands = (
-            wannier_builder["wannier90"]["parameters"]
-            .get_dict()
-            .get("exclude_bands", [])
-        )
-        nscf_overrides["pw"]["parameters"]["SYSTEM"]["nbnd"] = num_bands + len(
-            exclude_bands
-        )
+            num_bands = wannier_builder["wannier90"]["parameters"]["num_bands"]
+            exclude_bands = (
+                wannier_builder["wannier90"]["parameters"]
+                .get_dict()
+                .get("exclude_bands", [])
+            )
+            nscf_overrides["pw"]["parameters"]["SYSTEM"]["nbnd"] = num_bands + len(
+                exclude_bands
+            )
 
-        nscf_builder = PwBaseWorkChain.get_builder_from_protocol(
-            code=codes["pw"],
-            structure=structure,
-            protocol=protocol,
-            overrides=nscf_overrides,
-            electronic_type=electronic_type,
-            spin_type=pw_spin_type,
-            initial_magnetic_moments=initial_magnetic_moments,
-        )
-        # Use explicit list of kpoints generated by wannier builder.
-        # Since the QE auto generated kpoints might be different from wannier90, here we explicitly
-        # generate a list of kpoint coordinates to avoid discrepancies.
-        nscf_builder.pop("kpoints_distance", None)
-        nscf_builder.kpoints = wannier_builder["wannier90"]["kpoints"]
+            nscf_builder = PwBaseWorkChain.get_builder_from_protocol(
+                code=codes["pw"],
+                structure=structure,
+                protocol=protocol,
+                overrides=nscf_overrides,
+                electronic_type=electronic_type,
+                spin_type=pw_spin_type,
+                initial_magnetic_moments=initial_magnetic_moments,
+            )
+            # Use explicit list of kpoints generated by wannier builder.
+            # Since the QE auto generated kpoints might be different from wannier90, here we explicitly
+            # generate a list of kpoint coordinates to avoid discrepancies.
+            nscf_builder.pop("kpoints_distance", None)
+            nscf_builder.kpoints = wannier_builder["wannier90"]["kpoints"]
 
-        # Remove workchain excluded inputs
-        nscf_builder["pw"].pop("structure", None)
-        nscf_builder.pop("clean_workdir", None)
-        builder.nscf = nscf_builder._inputs(prune=True)
+            # Remove workchain excluded inputs
+            nscf_builder["pw"].pop("structure", None)
+            nscf_builder.pop("clean_workdir", None)
+            builder.nscf = nscf_builder._inputs(prune=True)
+            if scf_parent_folder is not None:
+                # ``setup`` takes this as the starting charge density when it finds no
+                # scf namespace, and ``run_nscf`` passes it on to the nscf calculation.
+                builder.nscf["pw"]["parent_folder"] = scf_parent_folder
 
         # Prepare projwfc builder
         if projection_type == WannierProjectionType.SCDM:
@@ -617,7 +648,19 @@ class Wannier90WorkChain(
                 spin_non_collinear=spin_non_collinear,
             )
         if exclude_semicore:
-            pseudo_orbitals = get_pseudo_orbitals(builder["scf"]["pw"]["pseudos"])
+            # The semicore states are read off the pseudopotentials, which reach the
+            # builder only through a pw namespace.
+            if run_scf:
+                pseudos = builder["scf"]["pw"]["pseudos"]
+            elif run_nscf:
+                pseudos = builder["nscf"]["pw"]["pseudos"]
+            else:
+                raise ValueError(
+                    "Cannot determine the semicore states when `nscf_parent_folder` "
+                    "leaves no pw namespace: pass `exclude_semicore=False` and set "
+                    "`exclude_bands` in the `wannier90` overrides instead."
+                )
+            pseudo_orbitals = get_pseudo_orbitals(pseudos)
             if projection_type == WannierProjectionType.ATOMIC_PROJECTORS_EXTERNAL:
                 exclude_projectors = get_semicore_list_ext(
                     structure, external_projectors, pseudo_orbitals, spin_non_collinear
@@ -641,6 +684,10 @@ class Wannier90WorkChain(
         # Remove workchain excluded inputs
         pw2wannier90_builder.pop("clean_workdir", None)
         builder.pw2wannier90 = pw2wannier90_builder._inputs(prune=True)
+        if nscf_parent_folder is not None:
+            # ``setup`` takes this as the starting folder when it finds neither pw
+            # namespace, and ``run_pw2wannier90`` passes it on to the calculation.
+            builder.pw2wannier90["pw2wannier90"]["parent_folder"] = nscf_parent_folder
 
         # A dictionary containing key info of Wannierisation and will be printed when the function returns.
         if summary is None:

--- a/tests/workflows/protocols/test_wannier90.py
+++ b/tests/workflows/protocols/test_wannier90.py
@@ -298,19 +298,58 @@ def test_nscf_parent_folder_validates(
     )
 
 
+def _atom_proj_exclude(builder):
+    """Return the pw2wannier90 `atom_proj_exclude`, whatever case the namelist key has."""
+    parameters = builder.pw2wannier90.pw2wannier90.parameters.get_dict()
+    namelist = {key.lower(): value for key, value in parameters.items()}["inputpp"]
+    return namelist["atom_proj_exclude"]
+
+
+@pytest.mark.parametrize("structure", ("BaTiO3", "GaAs"))
 def test_nscf_parent_folder_semicore(
+    generate_builder_inputs, generate_remote_data, fixture_localhost, structure
+):
+    """Test the semicore states are the same whether or not a pw namespace is assembled."""
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+    # Atomic projectors carry the semicore list into the pw2wannier90 parameters,
+    # where SCDM would not expose it.
+    kwargs = {
+        "projection_type": WannierProjectionType.ATOMIC_PROJECTORS_QE,
+        "print_summary": False,
+    }
+
+    default = Wannier90WorkChain.get_builder_from_protocol(
+        **generate_builder_inputs(structure), **kwargs
+    )
+
+    inputs = generate_builder_inputs(structure)
+    inputs["codes"].pop("pw")
+    reused = Wannier90WorkChain.get_builder_from_protocol(
+        **inputs, nscf_parent_folder=remote, **kwargs
+    )
+
+    excluded = _atom_proj_exclude(default)
+    # The structures are chosen to have semicore states, so this is not a
+    # comparison of two empty lists.
+    assert excluded
+    assert _atom_proj_exclude(reused) == excluded
+
+
+def test_nscf_parent_folder_semicore_unknown_family(
     generate_builder_inputs, generate_remote_data, fixture_localhost
 ):
-    """Test the semicore states cannot be resolved without a pw namespace to read pseudos from."""
+    """Test an unresolvable pseudopotential family is reported when no pw namespace holds one."""
     remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
-
     inputs = generate_builder_inputs()
     inputs["codes"].pop("pw")
 
-    with pytest.raises(ValueError, match=r"Cannot determine the semicore states"):
+    with pytest.raises(
+        ValueError, match=r"pseudo family `NoSuchFamily/9.9` is not installed"
+    ):
         Wannier90WorkChain.get_builder_from_protocol(
             **inputs,
             nscf_parent_folder=remote,
+            pseudo_family="NoSuchFamily/9.9",
             exclude_semicore=True,
             print_summary=False,
         )

--- a/tests/workflows/protocols/test_wannier90.py
+++ b/tests/workflows/protocols/test_wannier90.py
@@ -177,3 +177,140 @@ def test_force_parity(generate_builder_inputs, data_regression, serialize_builde
 
     assert isinstance(builder, ProcessBuilder)
     data_regression.check(serialize_builder(builder))
+
+
+def test_parent_folders_mutually_exclusive(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test passing both parent folders is rejected."""
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    with pytest.raises(ValueError, match=r"mutually exclusive"):
+        Wannier90WorkChain.get_builder_from_protocol(
+            **generate_builder_inputs(),
+            scf_parent_folder=remote,
+            nscf_parent_folder=remote,
+            print_summary=False,
+        )
+
+
+def test_pw_code_required_by_default(generate_builder_inputs):
+    """Test the `pw` code stays required when the scf/nscf namespaces are populated."""
+    inputs = generate_builder_inputs()
+    inputs["codes"].pop("pw")
+
+    with pytest.raises(ValueError, match=r"does not contain the required key: pw"):
+        Wannier90WorkChain.get_builder_from_protocol(**inputs, print_summary=False)
+
+
+def test_scf_parent_folder(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test an scf parent folder drops the scf namespace but keeps the nscf one."""
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    builder = Wannier90WorkChain.get_builder_from_protocol(
+        **generate_builder_inputs(),
+        scf_parent_folder=remote,
+        print_summary=False,
+    )
+
+    inputs = builder._inputs(prune=True)  # pylint: disable=protected-access
+    assert "scf" not in inputs
+    assert "nscf" in inputs
+    assert inputs["nscf"]["pw"]["parent_folder"] is remote
+
+    # The nscf still runs pw.x, so the `pw` code remains required.
+    codes = generate_builder_inputs()
+    codes["codes"].pop("pw")
+    with pytest.raises(ValueError, match=r"does not contain the required key: pw"):
+        Wannier90WorkChain.get_builder_from_protocol(
+            **codes, scf_parent_folder=remote, print_summary=False
+        )
+
+
+def test_scf_parent_folder_validates(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test the workchain accepts an scf-less builder without further wiring."""
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    builder = Wannier90WorkChain.get_builder_from_protocol(
+        **generate_builder_inputs(),
+        scf_parent_folder=remote,
+        print_summary=False,
+    )
+
+    assert (
+        Wannier90WorkChain.spec().inputs.validate(
+            builder._inputs(prune=True)  # pylint: disable=protected-access
+        )
+        is None
+    )
+
+
+def test_nscf_parent_folder(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test an nscf parent folder drops both pw namespaces and the `pw` code."""
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    inputs = generate_builder_inputs()
+    inputs["codes"].pop("pw")
+
+    builder = Wannier90WorkChain.get_builder_from_protocol(
+        **inputs,
+        nscf_parent_folder=remote,
+        exclude_semicore=False,
+        print_summary=False,
+    )
+
+    assert isinstance(builder, ProcessBuilder)
+
+    pruned = builder._inputs(prune=True)  # pylint: disable=protected-access
+    assert "scf" not in pruned
+    assert "nscf" not in pruned
+    assert "wannier90" in pruned
+    assert pruned["pw2wannier90"]["pw2wannier90"]["parent_folder"] is remote
+
+
+def test_nscf_parent_folder_validates(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test the workchain accepts the builder as returned, with no post-assembly wiring."""
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    inputs = generate_builder_inputs()
+    inputs["codes"].pop("pw")
+
+    builder = Wannier90WorkChain.get_builder_from_protocol(
+        **inputs,
+        nscf_parent_folder=remote,
+        exclude_semicore=False,
+        print_summary=False,
+    )
+
+    assert (
+        Wannier90WorkChain.spec().inputs.validate(
+            builder._inputs(prune=True)  # pylint: disable=protected-access
+        )
+        is None
+    )
+
+
+def test_nscf_parent_folder_semicore(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test the semicore states cannot be resolved without a pw namespace to read pseudos from."""
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    inputs = generate_builder_inputs()
+    inputs["codes"].pop("pw")
+
+    with pytest.raises(ValueError, match=r"Cannot determine the semicore states"):
+        Wannier90WorkChain.get_builder_from_protocol(
+            **inputs,
+            nscf_parent_folder=remote,
+            exclude_semicore=True,
+            print_summary=False,
+        )

--- a/tests/workflows/protocols/test_wannier90.py
+++ b/tests/workflows/protocols/test_wannier90.py
@@ -7,7 +7,10 @@ from aiida.plugins import WorkflowFactory
 
 from aiida_quantumespresso.common.types import ElectronicType, SpinType
 
-from aiida_wannier90_workflows.common.types import WannierProjectionType
+from aiida_wannier90_workflows.common.types import (
+    WannierFrozenType,
+    WannierProjectionType,
+)
 
 Wannier90WorkChain = WorkflowFactory("wannier90_workflows.wannier90")
 
@@ -353,3 +356,89 @@ def test_nscf_parent_folder_semicore_unknown_family(
             exclude_semicore=True,
             print_summary=False,
         )
+
+
+def test_nscf_parent_folder_scdm_setup(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test the default SCDM projector (which runs projwfc) starts `setup` cleanly.
+
+    With both scf and nscf skipped, `setup` reaches its projwfc branch before its
+    pw2wannier90 one, so the builder must wire the reused folder onto `projwfc` too.
+    """
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    inputs = generate_builder_inputs()
+    inputs["codes"].pop("pw")
+
+    builder = Wannier90WorkChain.get_builder_from_protocol(
+        **inputs,
+        nscf_parent_folder=remote,
+        exclude_semicore=False,
+        print_summary=False,
+    )
+    pruned = builder._inputs(prune=True)  # pylint: disable=protected-access
+    assert pruned["projwfc"]["projwfc"]["parent_folder"] is remote
+
+    process = Wannier90WorkChain(inputs=pruned)
+    process.setup()
+    assert process.ctx.current_folder is remote
+
+
+def test_nscf_parent_folder_atomic_projectors_qe_setup(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test atomic projectors (no projwfc) still starts `setup` from pw2wannier90.
+
+    `ATOMIC_PROJECTORS_QE` without `ENERGY_AUTO` never populates the `projwfc`
+    namespace, so `setup` falls through to its pw2wannier90 branch, unaffected by
+    the projwfc wiring added for the SCDM/`ENERGY_AUTO` cases.
+    """
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    inputs = generate_builder_inputs()
+    inputs["codes"].pop("pw")
+
+    builder = Wannier90WorkChain.get_builder_from_protocol(
+        **inputs,
+        nscf_parent_folder=remote,
+        exclude_semicore=False,
+        projection_type=WannierProjectionType.ATOMIC_PROJECTORS_QE,
+        print_summary=False,
+    )
+    pruned = builder._inputs(prune=True)  # pylint: disable=protected-access
+    assert "projwfc" not in pruned
+    assert pruned["pw2wannier90"]["pw2wannier90"]["parent_folder"] is remote
+
+    process = Wannier90WorkChain(inputs=pruned)
+    process.setup()
+    assert process.ctx.current_folder is remote
+
+
+def test_nscf_parent_folder_energy_auto_setup(
+    generate_builder_inputs, generate_remote_data, fixture_localhost
+):
+    """Test `frozen_type=ENERGY_AUTO` with a non-SCDM projector also runs projwfc.
+
+    This reaches the same `setup` projwfc branch as the SCDM default, via a
+    different `run_projwfc` condition in `get_builder_from_protocol`.
+    """
+    remote = generate_remote_data(fixture_localhost, "/tmp", "quantumespresso.pw")
+
+    inputs = generate_builder_inputs()
+    inputs["codes"].pop("pw")
+
+    builder = Wannier90WorkChain.get_builder_from_protocol(
+        **inputs,
+        nscf_parent_folder=remote,
+        exclude_semicore=False,
+        projection_type=WannierProjectionType.ATOMIC_PROJECTORS_QE,
+        frozen_type=WannierFrozenType.ENERGY_AUTO,
+        print_summary=False,
+    )
+    pruned = builder._inputs(prune=True)  # pylint: disable=protected-access
+    assert pruned["projwfc"]["projwfc"]["parent_folder"] is remote
+
+    process = Wannier90WorkChain(inputs=pruned)
+    process.setup()
+    assert process.ctx.current_folder is remote


### PR DESCRIPTION
### Problem

`Wannier90WorkChain.get_builder_from_protocol` always assembles the `scf` and `nscf` namespaces and always demands a `pw` code, even though the workchain itself might not require them (it runs those steps only when the namespace is present in its inputs).

A caller reusing a charge density or an nscf folder computed elsewhere is forced to provide a pw.x code that never runs, then delete both namespaces from the returned builder before submitting.

### Changes

- Add an `nscf_parent_folder` argument to `Wannier90WorkChain.get_builder_from_protocol`: if present, neither pw namespace is assembled, and the folder becomes the pw2wannier90 `parent_folder`, so the builder starts at the wannier90 step.
- Add an `scf_parent_folder` argument: if present, the scf namespace is skipped, the nscf is still assembled, and the folder becomes the nscf `parent_folder`.
- Reject passing both
- Require the `pw` code only when a pw namespace is assembled, so `nscf_parent_folder` lets the caller omit it from `codes` entirely.
- Give `check_codes` in `utils/workflows/builder/submit.py` a `required_codes` argument, matching the parameter of the same name already in `utils/code.py`.
- To keep `exlcude_semicore` working, read the semicore pseudopotentials from whichever pw namespace is present, and from the pseudo family and the structure when neither is

The builder comes back ready to submit rather than needing to be patched up afterwards. Defaults are unchanged.

```python
builder = Wannier90WorkChain.get_builder_from_protocol(
    codes={"pw2wannier90": pw2wannier90_code, "wannier90": w90_code},
    structure=structure,
    nscf_parent_folder=nscf_remote_folder,
)
```

### Testing

- A builder built with `nscf_parent_folder` and no `pw` code passes `Wannier90WorkChain.spec().inputs.validate()`
- The same holds for `scf_parent_folder`
- `scf_parent_folder` still requires `pw`
- With `nscf_parent_folder`, `exclude_semicore` produces exactly the semicore list the full-assembly path produces
- Passing both parent folders raises
- an unresolvable pseudo family is reported
- the default path still rejects a missing `pw` code with the original error