### PR TITLE
Require Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     services:
       postgres:
@@ -85,7 +85,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ classifiers = [
     "Intended Audience :: Science/Research"
 ]
 keywords = ["aiida", "plugin", "wannier90"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "aiida-core>=2.0,<3",
     "aiida-pseudo>=0.6",
@@ -201,12 +200,12 @@ known_aiida_wannier90 = ['aiida_wannier90']
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py39
+envlist = py310
 
 [testenv]
 usedevelop=True
 
-[testenv:py{39,310,311,312}]
+[testenv:py{310,311,312}]
 description = Run the test suite against a python version
 extras = testing
 commands = pytest {posargs}


### PR DESCRIPTION
3.9 reached EOL almost a year ago. aiida-core declares `>=3.10` from 2.9.0 and aiida-quantumespresso from 4.16.0

- `requires-python` moves to `>=3.10`
- the 3.9 trove classifier is dropped
- 3.9 leaves the CI test matrix, and the docs job moves to 3.10
- tox's default env and the parametrised env list follow