### PR TITLE
Set `current_folder` after checking the wannier90 run

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -1209,21 +1209,17 @@ class Wannier90WorkChain(
         """Verify that the `Wannier90BaseWorkChain` for the wannier90 run successfully finished."""
         if not self.ctx.spin_collinear:
             workchain = self.ctx.workchain_wannier90
-            self.ctx.current_folder = self.ctx.workchain_wannier90.outputs.remote_folder
             if not workchain.is_finished_ok:
                 self.report(
                     f"{workchain.process_label} failed with exit status {workchain.exit_status}"
                 )
                 return self.exit_codes.ERROR_SUB_PROCESS_FAILED_WANNIER90
+            self.ctx.current_folder = workchain.outputs.remote_folder
         else:
             workchain = [
                 self.ctx.workchain_wannier90_up,
                 self.ctx.workchain_wannier90_down,
             ]
-            self.ctx.current_folder_up, self.ctx.current_folder_down = (
-                self.ctx.workchain_wannier90_up.outputs.remote_folder,
-                self.ctx.workchain_wannier90_down.outputs.remote_folder,
-            )
             self.ctx.workchain_wannier90 = workchain
 
             for workchain_spin in workchain:
@@ -1232,6 +1228,13 @@ class Wannier90WorkChain(
                         f"{workchain_spin.process_label} failed with exit status {workchain_spin.exit_status}"
                     )
                     return self.exit_codes.ERROR_SUB_PROCESS_FAILED_WANNIER90
+
+            self.ctx.current_folder_up = (
+                self.ctx.workchain_wannier90_up.outputs.remote_folder
+            )
+            self.ctx.current_folder_down = (
+                self.ctx.workchain_wannier90_down.outputs.remote_folder
+            )
 
     def results(self):  # pylint: disable=inconsistent-return-statements
         """Attach the desired output nodes directly as outputs of the workchain."""

--- a/tests/workflows/test_wannier90.py
+++ b/tests/workflows/test_wannier90.py
@@ -3,6 +3,7 @@
 import io
 
 from plumpy.process_states import ProcessState
+import pytest
 
 from aiida import orm
 from aiida.common import LinkType
@@ -190,4 +191,41 @@ def test_scdm(
     assert all(
         _ in workchain.outputs
         for _ in ("scf", "nscf", "projwfc", "wannier90_pp", "pw2wannier90", "wannier90")
+    )
+
+
+@pytest.mark.parametrize("spin_collinear", (False, True))
+def test_inspect_wannier90_failed(
+    generate_workchain_wannier90,
+    fixture_localhost,
+    generate_calc_job_node,
+    spin_collinear,
+):  # pylint: disable=redefined-outer-name
+    """Test that a failed wannier90 run is reported through its exit code.
+
+    A ``Wannier90BaseWorkChain`` that did not finish successfully has no
+    ``remote_folder`` output, so reading it hides the real failure behind an
+    attribute error.
+    """
+
+    def generate_failed_workchain():
+        node = generate_calc_job_node("wannier90.wannier90", fixture_localhost)
+        node.set_process_state(ProcessState.FINISHED)
+        node.set_exit_status(400)
+        assert "remote_folder" not in node.outputs
+        return node
+
+    workchain = generate_workchain_wannier90()
+    assert workchain.setup() is None
+    workchain.ctx.spin_collinear = spin_collinear
+
+    if spin_collinear:
+        workchain.ctx.workchain_wannier90_up = generate_failed_workchain()
+        workchain.ctx.workchain_wannier90_down = generate_failed_workchain()
+    else:
+        workchain.ctx.workchain_wannier90 = generate_failed_workchain()
+
+    assert (
+        workchain.inspect_wannier90()
+        == workchain.exit_codes.ERROR_SUB_PROCESS_FAILED_WANNIER90
     )


### PR DESCRIPTION
When a wannier90 run inside `Wannier90WorkChain` fails, the user is told the wrong thing. `inspect_wannier90` reads `remote_folder` off the sub-workchain and stores it in the context *before* testing `is_finished_ok`; a `Wannier90BaseWorkChain` that did not finish successfully has no `remote_folder` output, so the read raises `NotExistent` and the parent workchain dies as `EXCEPTED` on a missing output. The wannier90 error that actually stopped the calculation — not enough states in the disentanglement window, out of memory, whatever the base workchain's handlers gave up on — never reaches the report, and `ERROR_SUB_PROCESS_FAILED_WANNIER90` is never returned.

The neighbouring steps (`inspect_scf`, `inspect_nscf`) already check first and read second; this brings `inspect_wannier90` in line.

## Changes

- Check `is_finished_ok` before touching `outputs.remote_folder`, in both the non-collinear branch and the spin-collinear one, so a failed run returns `ERROR_SUB_PROCESS_FAILED_WANNIER90` and the report names the sub-process exit status.

## Testing

- `test_inspect_wannier90_failed`, parametrised over both spin branches, puts a failed sub-process with no `remote_folder` output into the context and asserts `inspect_wannier90` returns `ERROR_SUB_PROCESS_FAILED_WANNIER90`. On `main` both parametrisations fail with `NotExistent` raised from `KeyError: 'remote_folder'` — that is the bug reproduced, and it is what distinguishes this fix from a cosmetic reordering.
- Full suite green (163 tests).

## Not fixed here

`inspect_pw2wannier90` has the same ordering, and additionally does not return `ERROR_SUB_PROCESS_FAILED_PW2WANNIER90` in its non-collinear branch — it reports and falls through. Correcting the ordering there without also adding the missing `return` would trade one confusing failure for another, and the added `return` is a behaviour change (a failed pw2wannier90 would abort the workchain rather than continue) that deserves its own review (tracked in #110 )