### PR TITLE
Add Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     services:
       postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Natural Language :: English",
     "Topic :: Scientific/Engineering :: Physics",
     "Intended Audience :: Science/Research"
@@ -205,7 +207,7 @@ envlist = py310
 [testenv]
 usedevelop=True
 
-[testenv:py{310,311,312}]
+[testenv:py{310,311,312,313,314}]
 description = Run the test suite against a python version
 extras = testing
 commands = pytest {posargs}


### PR DESCRIPTION
## Problem

The trove classifiers, CI matrix, and tox envlist stop at Python 3.12, but nothing in the dependency chain actually requires that ceiling: aiida-core and aiida-quantumespresso both already declare `Programming Language :: Python :: 3.13` and `:: 3.14` with `requires-python = '>=3.10'`. This branch tests whether the plugin itself works on the newer interpreters and adds the ones that do.

## Changes

- Added the `Programming Language :: Python :: 3.13` and `:: 3.14` classifiers.
- Added `3.13` and `3.14` to the `tests` job matrix in `.github/workflows/ci.yml`.
- Added `py313` and `py314` to the tox envlist in `pyproject.toml`.

Left untouched: the pre-commit job's interpreter (3.12, only needs one working version), the docs job's interpreter (3.10), and `requires-python` (already `>=3.10`, no upper bound to move). `.readthedocs.yml` pins Python 3.8 (?! -- left alone).

This stacks on #102