### PR TITLE
Set `dis_froz_proj` for the projectability frozen types

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/base/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/wannier90.py
@@ -470,6 +470,9 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             elif frozen_type == WannierFrozenType.PROJECTABILITY:
                 parameters.update(
                     {
+                        # wannier90 reads dis_proj_min/dis_proj_max only when
+                        # dis_froz_proj is true
+                        "dis_froz_proj": True,
                         "dis_proj_min": 0.01,
                         "dis_proj_max": 0.95,
                     }
@@ -478,6 +481,9 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
                 inputs["shift_energy_windows"] = True
                 parameters.update(
                     {
+                        # wannier90 reads dis_proj_min/dis_proj_max only when
+                        # dis_froz_proj is true
+                        "dis_froz_proj": True,
                         "dis_proj_min": 0.01,
                         "dis_proj_max": 0.95,
                         "dis_froz_max": +2.0,  # relative to fermi_energy

--- a/tests/workflows/protocols/base/test_wannier90.py
+++ b/tests/workflows/protocols/base/test_wannier90.py
@@ -156,6 +156,34 @@ def test_frozen_type(
     data_regression.check(serialize_builder(builder))
 
 
+@pytest.mark.parametrize(
+    "frozen_type",
+    (
+        WannierFrozenType.PROJECTABILITY,
+        WannierFrozenType.FIXED_PLUS_PROJECTABILITY,
+    ),
+)
+def test_frozen_type_projectability_enables_dis_froz_proj(
+    fixture_code, generate_structure, frozen_type
+):
+    """Test that the projectability frozen types switch on ``dis_froz_proj``.
+
+    wannier90 ignores ``dis_proj_min``/``dis_proj_max`` unless ``dis_froz_proj``
+    is true.
+    """
+    code = fixture_code("wannier90.wannier90")
+    structure = generate_structure("Si")
+
+    builder = Wannier90BaseWorkChain.get_builder_from_protocol(
+        code, structure=structure, frozen_type=frozen_type
+    )
+
+    parameters = builder["wannier90"]["parameters"].get_dict()
+    assert parameters["dis_froz_proj"] is True
+    assert "dis_proj_min" in parameters
+    assert "dis_proj_max" in parameters
+
+
 def test_parameter_overrides(
     fixture_code, generate_structure, data_regression, serialize_builder
 ):

--- a/tests/workflows/protocols/base/test_wannier90/test_default.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_default.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_disentanglement_type_WannierDisentanglementType_SMV_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_disentanglement_type_WannierDisentanglementType_SMV_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_electronic_type_ElectronicType_INSULATOR_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_electronic_type_ElectronicType_INSULATOR_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_electronic_type_ElectronicType_METAL_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_electronic_type_ElectronicType_METAL_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_frozen_type_WannierFrozenType_FIXED_PLUS_PROJECTABILITY_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_frozen_type_WannierFrozenType_FIXED_PLUS_PROJECTABILITY_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_frozen_type_WannierFrozenType_PROJECTABILITY_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_frozen_type_WannierFrozenType_PROJECTABILITY_.yml
@@ -16,6 +16,7 @@ wannier90:
     conv_tol: 2.0e-07
     conv_window: 3
     dis_conv_tol: 2.0e-07
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_metadata_overrides.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_metadata_overrides.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_parameter_overrides.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_parameter_overrides.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_projection_type_WannierProjectionType_ATOMIC_PROJECTORS_QE_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_projection_type_WannierProjectionType_ATOMIC_PROJECTORS_QE_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_projection_type_WannierProjectionType_SCDM_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_projection_type_WannierProjectionType_SCDM_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_settings_overrides.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_settings_overrides.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/base/test_wannier90/test_spin_type_SpinType_NONE_.yml
+++ b/tests/workflows/protocols/base/test_wannier90/test_spin_type_SpinType_NONE_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_BaTiO3_.yml
@@ -116,6 +116,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 5.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_GaAs_.yml
@@ -111,6 +111,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_H2O_.yml
@@ -105,6 +105,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 3.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_bands/test_atomic_projectors_qe_Si_.yml
@@ -103,6 +103,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_BaTiO3_.yml
@@ -85,6 +85,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 5.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_GaAs_.yml
@@ -81,6 +81,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_H2O_.yml
@@ -75,6 +75,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 3.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_open_grid/test_atomic_projectors_qe_Si_.yml
@@ -74,6 +74,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_BaTiO3_.yml
@@ -117,6 +117,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 5.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_GaAs_.yml
@@ -112,6 +112,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_H2O_.yml
@@ -106,6 +106,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 3.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_optimize/test_atomic_projectors_qe_Si_.yml
@@ -104,6 +104,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_BaTiO3_.yml
@@ -129,6 +129,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 5.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_GaAs_.yml
@@ -131,6 +131,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_H2O_.yml
@@ -110,6 +110,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 3.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
+++ b/tests/workflows/protocols/test_optimize/test_spin_orbit_Si_.yml
@@ -108,6 +108,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_protocols/test_overrides_overrides4_Wannier90OptimizeWorkChain_.yml
+++ b/tests/workflows/protocols/test_protocols/test_overrides_overrides4_Wannier90OptimizeWorkChain_.yml
@@ -17,6 +17,7 @@ wannier90:
     conv_window: 3
     dis_conv_tol: 2.0e-07
     dis_froz_max: 2.0
+    dis_froz_proj: true
     dis_num_iter: 4000
     dis_proj_max: 0.95
     dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_BaTiO3_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_BaTiO3_.yml
@@ -115,6 +115,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 5.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_GaAs_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_GaAs_.yml
@@ -110,6 +110,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_H2O_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_H2O_.yml
@@ -104,6 +104,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 3.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01

--- a/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_Si_.yml
+++ b/tests/workflows/protocols/test_wannier90/test_atomic_projectors_qe_Si_.yml
@@ -102,6 +102,7 @@ wannier90:
       conv_window: 3
       dis_conv_tol: 2.0e-07
       dis_froz_max: 2.0
+      dis_froz_proj: true
       dis_num_iter: 4000
       dis_proj_max: 0.95
       dis_proj_min: 0.01


### PR DESCRIPTION
## Problem

`WannierFrozenType.PROJECTABILITY` and `WannierFrozenType.FIXED_PLUS_PROJECTABILITY` (the default) write `dis_proj_min = 0.01` and `dis_proj_max = 0.95` into the wannier90 parameters. wannier90 reads those two keywords only when `dis_froz_proj` is true, and the protocol never set it — so every builder made with either frozen type asked for a projectability-based frozen window and got none.

## Changes

- Set `dis_froz_proj = True` alongside `dis_proj_min`/`dis_proj_max` in both projectability frozen types, so the window the protocol asks for is the one wannier90 applies.
- Refresh the protocol regression files. The diff is insertions only: one `dis_froz_proj: true` line per affected builder, no other parameter changed.

## Testing

- `test_frozen_type_projectability_enables_dis_froz_proj` asserts the key is written for both `PROJECTABILITY` and `FIXED_PLUS_PROJECTABILITY`. Run against the unpatched builder it fails with `KeyError: 'dis_froz_proj'`, so it discriminates the fix rather than merely passing alongside it.
- Full suite green (163 tests; 161 before this branch, plus the two new parametrisations).

## A follow-up worth considering

This restores the thresholds the protocol already chose — `dis_proj_min = 0.01`, `dis_proj_max = 0.95`. It is worth asking whether the protocol should state them at all.

The latest develop version of wannier90 determines the projectability thresholds itself, through `dis_proj_auto`, which is on by default and classifies the computed projectabilities rather than taking two fixed numbers. Explicit values switch it off.

Dropping them from the projectability frozen types would let wannier90 choose. That is a behaviour change for every existing user of these protocols, would need us to increase the required wannier90 version to its _next_ release, and belongs in its own pull request with its own discussion — hence a note here rather than a second commit.