### PR TITLE
Expose `only_valence` on the protocol builders

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/base/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/base/wannier90.py
@@ -247,6 +247,7 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         projection_type: WannierProjectionType = WannierProjectionType.ATOMIC_PROJECTORS_QE,
         disentanglement_type: WannierDisentanglementType = WannierDisentanglementType.SMV,
         frozen_type: WannierFrozenType = WannierFrozenType.FIXED_PLUS_PROJECTABILITY,
+        only_valence: ty.Optional[bool] = None,
     ) -> ProcessBuilder:
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
@@ -258,6 +259,11 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         :type protocol: str, optional
         :param overrides: [description], defaults to None
         :type overrides: dict, optional
+        :param only_valence: Wannierize the valence manifold alone, so that
+            ``num_bands`` counts occupied states only and ``num_wann ==
+            num_bands``. Defaults to None, meaning ``electronic_type ==
+            ElectronicType.INSULATOR``.
+        :type only_valence: bool, optional
         :return: [description]
         :rtype: ProcessBuilder
         """
@@ -314,7 +320,8 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         )
 
         # Set `num_bands`, `num_wann`, also take care of semicore states
-        only_valence = electronic_type == ElectronicType.INSULATOR
+        if only_valence is None:
+            only_valence = electronic_type == ElectronicType.INSULATOR
         spin_polarized = spin_type == SpinType.COLLINEAR
         spin_orbit_coupling = spin_type == SpinType.SPIN_ORBIT
         spin_non_collinear = spin_orbit_coupling or spin_type == SpinType.NON_COLLINEAR
@@ -370,7 +377,7 @@ class Wannier90BaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
                 spin_orbit_coupling=spin_orbit_coupling,
             )
 
-        if electronic_type == ElectronicType.INSULATOR:
+        if only_valence:
             num_wann = num_bands
         else:
             num_wann = num_projs

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -305,6 +305,7 @@ class Wannier90WorkChain(
         retrieve_matrices: bool = False,
         compute_fermi_surface: bool = False,
         fermi_surface_kpoint_distance: float = 0.04,
+        only_valence: ty.Optional[bool] = None,
         print_summary: bool = True,
         summary: dict = None,
     ) -> ProcessBuilder:
@@ -348,6 +349,9 @@ class Wannier90WorkChain(
         :param retrieve_matrices: if True retrieve amn/mmn/eig/chk/spin files.
         :param compute_fermi_surface: if True compute the Fermi surface.
         :param fermi_surface_kpoint_distance: the distance between kpoints for the Fermi surface calculation.
+        :param only_valence: Wannierize the valence manifold alone, so that ``num_bands``
+        counts occupied states only and ``num_wann == num_bands``. Default to None,
+        meaning ``electronic_type == ElectronicType.INSULATOR``.
         :param print_summary: if True print a summary of key input parameters
         :param summary: A dict containing key input parameters and can be printed out
         when the `get_builder_from_protocol` returns, to let user have a quick check of the
@@ -526,6 +530,7 @@ class Wannier90WorkChain(
             frozen_type=frozen_type,
             pseudo_family=pseudo_family,
             external_projectors=external_projectors,
+            only_valence=only_valence,
         )
         # Remove workchain excluded inputs
         wannier_builder["wannier90"].pop("structure", None)

--- a/tests/workflows/protocols/base/test_wannier90.py
+++ b/tests/workflows/protocols/base/test_wannier90.py
@@ -156,6 +156,40 @@ def test_frozen_type(
     data_regression.check(serialize_builder(builder))
 
 
+def test_only_valence(fixture_code, generate_structure):
+    """Test that ``only_valence`` overrides the inference from ``electronic_type``."""
+    code = fixture_code("wannier90.wannier90")
+    structure = generate_structure("Si")
+
+    def parameters(**kwargs):
+        builder = Wannier90BaseWorkChain.get_builder_from_protocol(
+            code, structure=structure, **kwargs
+        )
+        return builder["wannier90"]["parameters"].get_dict()
+
+    # Si has 8 valence electrons, hence 4 occupied bands
+    num_valence_bands = 4
+
+    inferred_metal = parameters(electronic_type=ElectronicType.METAL)
+    assert inferred_metal["num_bands"] > num_valence_bands
+    assert inferred_metal["num_wann"] != inferred_metal["num_bands"]
+
+    inferred_insulator = parameters(electronic_type=ElectronicType.INSULATOR)
+    assert inferred_insulator["num_bands"] == num_valence_bands
+    assert inferred_insulator["num_wann"] == num_valence_bands
+
+    # An explicit value wins over the inference, in both directions
+    forced_valence = parameters(electronic_type=ElectronicType.METAL, only_valence=True)
+    assert forced_valence["num_bands"] == num_valence_bands
+    assert forced_valence["num_wann"] == num_valence_bands
+
+    forced_conduction = parameters(
+        electronic_type=ElectronicType.INSULATOR, only_valence=False
+    )
+    assert forced_conduction["num_bands"] == inferred_metal["num_bands"]
+    assert forced_conduction["num_wann"] == inferred_metal["num_wann"]
+
+
 def test_parameter_overrides(
     fixture_code, generate_structure, data_regression, serialize_builder
 ):


### PR DESCRIPTION
```python
# Wannierize the valence manifold of a metal, or valence + conduction of an insulator
builder = Wannier90BaseWorkChain.get_builder_from_protocol(
    code, structure=structure, electronic_type=ElectronicType.INSULATOR, only_valence=False
)
```

## Problem

Whether a builder targets the occupied manifold alone or the occupied plus empty states is decided inside `Wannier90BaseWorkChain.get_builder_from_protocol` by a local variable, `only_valence = electronic_type == ElectronicType.INSULATOR`. It fixes both `num_bands` and `num_wann`. The inference is a good default but it is not always desired (e.g. Koopmans functionals).

## Changes

- Add `only_valence` as a keyword argument of `Wannier90BaseWorkChain.get_builder_from_protocol`, defaulting to None so the existing inference from `electronic_type` is what you get unless you say otherwise.
- Thread it through `Wannier90WorkChain.get_builder_from_protocol`; the subclasses (`Wannier90BandsWorkChain`, `Wannier90OptimizeWorkChain`, `Wannier90OpenGridWorkChain`) forward keyword arguments, so it reaches them unchanged.
- Choose `num_wann` from `only_valence` rather than re-testing `electronic_type`, so that the two cannot disagree. With the default this is the same expression; with an explicit `only_valence=True` it is what keeps `num_wann == num_bands` meaningful.