### PR TITLE
Add Fermi-Dirac and unweighted bands distances

### DIFF
--- a/src/aiida_wannier90_workflows/utils/bands/distance.py
+++ b/src/aiida_wannier90_workflows/utils/bands/distance.py
@@ -24,7 +24,82 @@ def compute_lower_cutoff(energy: np.array, lower_cutoff: float) -> np.array:
     return np.array(energy > lower_cutoff, dtype=int)
 
 
-def bands_distance_raw(  # pylint: disable=too-many-arguments,too-many-locals
+def as_bands_array(bands: ty.Union[orm.BandsData, np.array]) -> np.array:
+    """Return the eigenvalues of ``bands`` as a numpy array."""
+    if isinstance(bands, orm.BandsData):
+        return bands.get_bands()
+    return bands
+
+
+def _align_bands(
+    dft_bands: np.array,
+    wannier_bands: np.array,
+    exclude_list_dft: list = None,
+) -> ty.Tuple[np.array, np.array]:
+    """Drop the excluded DFT bands and truncate both arrays to a common shape.
+
+    Spin-collinear bands, of shape (num_spins, num_kpts, num_bands), are moved
+    to (num_kpts, num_bands, num_spins) first, so that the band index is always
+    the second one.
+
+    :param exclude_list_dft: if passed should be a list of the excluded bands,
+       1-indexed
+    :return: ``(dft_bands, wannier_bands)``, of equal shape.
+    """
+    if len(dft_bands.shape) == 3 and len(wannier_bands.shape) == 3:
+        dft_bands = np.moveaxis(dft_bands, [-2, -1], [0, 1])
+        wannier_bands = np.moveaxis(wannier_bands, [-2, -1], [0, 1])
+
+    if exclude_list_dft is None or len(exclude_list_dft) == 0:
+        dft_bands_filtered = dft_bands
+    else:
+        # Code taken and *adapted* from the workflow (function get_exclude_bands)
+        # in Fortran/W90: 1-based; in py: 0-based
+        xb_startzero_set = {idx - 1 for idx in exclude_list_dft}
+        keep_bands = np.array(
+            [idx for idx in range(dft_bands.shape[1]) if idx not in xb_startzero_set]
+        )
+
+        dft_bands_filtered = dft_bands[:, keep_bands]
+
+    # Check that the number of kpoints is the same
+    assert (
+        dft_bands_filtered.shape[0] == wannier_bands.shape[0]
+    ), f"Different number of kpoints {dft_bands_filtered.shape[0]} {wannier_bands.shape[0]}"
+    if dft_bands_filtered.shape[1] <= wannier_bands.shape[1]:
+        wannier_bands_filtered = wannier_bands[:, : dft_bands_filtered.shape[1]]
+    else:
+        wannier_bands_filtered = wannier_bands
+
+    dft_bands_to_compare = dft_bands_filtered[:, : wannier_bands_filtered.shape[1]]
+
+    return dft_bands_to_compare, wannier_bands_filtered
+
+
+def _compute_distance(
+    bands_energy_difference: np.array,
+    bands_weight: np.array,
+) -> tuple:
+    """Return the weighted RMS and maximum band differences.
+
+    :return: (bands_dist, max_dist, max_dist_2, max_dist_loc, max_dist_2_loc)
+    """
+    arr = bands_energy_difference**2 * bands_weight
+    bands_dist = np.sqrt(np.sum(arr) / np.sum(bands_weight))
+
+    # max distance
+    max_dist = np.sqrt(np.max(arr))
+    max_dist_loc = np.unravel_index(np.argmax(arr, axis=None), arr.shape)
+
+    arr_2 = np.abs(bands_energy_difference) * bands_weight
+    # max abs difference
+    max_dist_2 = np.max(arr_2)
+    max_dist_2_loc = np.unravel_index(np.argmax(arr_2, axis=None), arr_2.shape)
+
+    return (bands_dist, max_dist, max_dist_2, max_dist_loc, max_dist_2_loc)
+
+
+def bands_distance_raw(  # pylint: disable=too-many-arguments
     dft_bands: np.array,
     wannier_bands: np.array,
     mu: float,
@@ -39,76 +114,28 @@ def bands_distance_raw(  # pylint: disable=too-many-arguments,too-many-locals
        number of bands computed by the DFT code. In eV.
     :param wannier_bands: a numpy array of size (num_k x num_wan) where num_wan is
        number of Wannier functions.  In eV.
-    :para mu, sigma: in eV.
+    :param mu: in eV.
+    :param sigma: in eV.
     :param exclude_list_dft: if passed should be a list of the excluded bands,
        1-indexed
     :param gaussian_weight: if True, gaussian weight will be used instead of
         Fermi-Dirac
     """
+    dft_bands_to_compare, wannier_bands_filtered = _align_bands(
+        dft_bands, wannier_bands, exclude_list_dft
+    )
 
-    # When spin collinear bands, bands.shape == (num_spins, num_kpts, num_bands)
-    # Move it to bands.shape = (num_kpts, num_bands, num_spins), so we should not
-    # move the index position
-    if len(dft_bands.shape) == 3 and len(wannier_bands.shape) == 3:
-        dft_bands = np.moveaxis(dft_bands, [-2, -1], [0, 1])
-        wannier_bands = np.moveaxis(wannier_bands, [-2, -1], [0, 1])
-    if exclude_list_dft is None:
-        exclude_list_dft = []
-        dft_bands_filtered = dft_bands
-    else:
-        # Code taken and *adapted* from the workflow (function get_exclude_bands)
-        xb_startzero_set = {idx - 1 for idx in exclude_list_dft}
-        # in Fortran/W90: 1-based; in py: 0-based
-        keep_bands = np.array(
-            [idx for idx in range(dft_bands.shape[1]) if idx not in xb_startzero_set]
-        )
-
-        dft_bands_filtered = dft_bands[:, keep_bands]
-
-    # Check that the number of kpoints is the same
-    assert (
-        dft_bands_filtered.shape[0] == wannier_bands.shape[0]
-    ), f"Different number of kpoints {dft_bands_filtered.shape[0]} {wannier_bands.shape[0]}"
-    # assert dft_bands_filtered.shape[1] >= wannier_bands.shape[
-    #     1], f'Too few DFT bands w.r.t. Wannier {dft_bands_filtered.shape[1]} {wannier_bands.shape[1]}'
-    if dft_bands_filtered.shape[1] <= wannier_bands.shape[1]:
-        wannier_bands_filtered = wannier_bands[:, : dft_bands_filtered.shape[1]]
-    else:
-        wannier_bands_filtered = wannier_bands
-
-    dft_bands_to_compare = dft_bands_filtered[:, : wannier_bands_filtered.shape[1]]
+    weight_function = gaussian if gaussian_weight else fermi_dirac
+    cutoff_mask = compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
+    bands_weight_dft = weight_function(dft_bands_to_compare, mu, sigma) * cutoff_mask
+    bands_weight_wannier = (
+        weight_function(wannier_bands_filtered, mu, sigma) * cutoff_mask
+    )
+    bands_weight = np.sqrt(bands_weight_dft * bands_weight_wannier)
 
     bands_energy_difference = dft_bands_to_compare - wannier_bands_filtered
-    if gaussian_weight:
-        bands_weight_dft = gaussian(
-            dft_bands_to_compare, mu, sigma
-        ) * compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
-        bands_weight_wannier = gaussian(
-            wannier_bands_filtered, mu, sigma
-        ) * compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
-    else:
-        bands_weight_dft = fermi_dirac(
-            dft_bands_to_compare, mu, sigma
-        ) * compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
-        bands_weight_wannier = fermi_dirac(
-            wannier_bands_filtered, mu, sigma
-        ) * compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
 
-    bands_weight = np.sqrt(bands_weight_dft * bands_weight_wannier)
-    arr = bands_energy_difference**2 * bands_weight
-    bands_dist = np.sqrt(np.sum(arr) / np.sum(bands_weight))
-
-    # max distance
-    max_dist = np.sqrt(np.max(arr))
-    max_dist_loc = np.unravel_index(np.argmax(arr, axis=None), arr.shape)
-    # print(np.shape(arr), max_distance_loc)
-
-    arr_2 = np.abs(bands_energy_difference) * bands_weight
-    # max abs difference
-    max_dist_2 = np.max(arr_2)
-    max_dist_2_loc = np.unravel_index(np.argmax(arr_2, axis=None), arr_2.shape)
-
-    return (bands_dist, max_dist, max_dist_2, max_dist_loc, max_dist_2_loc)
+    return _compute_distance(bands_energy_difference, bands_weight)
 
 
 def bands_distance(
@@ -126,14 +153,8 @@ def bands_distance(
     :param exclude_list_dft: [description], defaults to None
     :return: [description], unit is eV.
     """
-    if isinstance(bands_dft, orm.BandsData):
-        dft_bands = bands_dft.get_bands()
-    else:
-        dft_bands = bands_dft
-    if isinstance(bands_wannier, orm.BandsData):
-        wannier_bands = bands_wannier.get_bands()
-    else:
-        wannier_bands = bands_wannier
+    dft_bands = as_bands_array(bands_dft)
+    wannier_bands = as_bands_array(bands_wannier)
 
     # mu_range = np.arange(-60, 40, 0.5)
     start = fermi_energy
@@ -163,69 +184,93 @@ def bands_distance(
     return dist
 
 
-def bands_distance_isolated(  # pylint: disable=too-many-locals
+def bands_distance_isolated(
     dft_bands: ty.Union[orm.BandsData, np.array],
     wannier_bands: ty.Union[orm.BandsData, np.array],
     exclude_list_dft: list = None,
     lower_cutoff: float = None,
 ) -> tuple:
-    """Calculate bands distance with specified group of bands.
+    """Calculate bands distance with every band above ``lower_cutoff`` weighted equally.
 
     :param dft_bands: a numpy array of size (num_k x num_dft) where num_dft is
        number of bands computed by the DFT code. In eV.
     :param wannier_bands: a numpy array of size (num_k x num_wan) where num_wan is
        number of Wannier functions.  In eV.
-    :para mu, sigma: in eV.
     :param exclude_list_dft: if passed should be a list of the excluded bands,
        1-indexed
+    :param lower_cutoff: bands below this energy, in eV, are dropped from the
+       comparison. Defaults to None, meaning keep every band.
     """
-    if isinstance(dft_bands, orm.BandsData):
-        dft_bands = dft_bands.get_bands()
-    if isinstance(wannier_bands, orm.BandsData):
-        wannier_bands = wannier_bands.get_bands()
-
-    if exclude_list_dft is None:
-        exclude_list_dft = []
-        dft_bands_filtered = dft_bands
-    else:
-        # Code taken and *adapted* from the workflow (function get_exclude_bands)
-        xb_startzero_set = {idx - 1 for idx in exclude_list_dft}
-        # in Fortran/W90: 1-based; in py: 0-based
-        keep_bands = np.array(
-            [idx for idx in range(dft_bands.shape[1]) if idx not in xb_startzero_set]
-        )
-
-        dft_bands_filtered = dft_bands[:, keep_bands]
-
-    # Check that the number of kpoints is the same
-    assert (
-        dft_bands_filtered.shape[0] == wannier_bands.shape[0]
-    ), f"Different number of kpoints {dft_bands_filtered.shape[0]} {wannier_bands.shape[0]}"
-    # assert dft_bands_filtered.shape[1] >= wannier_bands.shape[
-    #     1], f'Too few DFT bands w.r.t. Wannier {dft_bands_filtered.shape[1]} {wannier_bands.shape[1]}'
-    if dft_bands_filtered.shape[1] <= wannier_bands.shape[1]:
-        wannier_bands_filtered = wannier_bands[:, : dft_bands_filtered.shape[1]]
-    else:
-        wannier_bands_filtered = wannier_bands
-
-    dft_bands_to_compare = dft_bands_filtered[:, : wannier_bands_filtered.shape[1]]
+    dft_bands_to_compare, wannier_bands_filtered = _align_bands(
+        as_bands_array(dft_bands), as_bands_array(wannier_bands), exclude_list_dft
+    )
 
     bands_energy_difference = dft_bands_to_compare - wannier_bands_filtered
-    bands_weight_dft = compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
-    bands_weight_wannier = compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
-    bands_weight = np.sqrt(bands_weight_dft * bands_weight_wannier)
+    bands_weight = compute_lower_cutoff(dft_bands_to_compare, lower_cutoff)
 
-    arr = bands_energy_difference**2 * bands_weight
-    bands_dist = np.sqrt(np.sum(arr) / np.sum(bands_weight))
+    return _compute_distance(bands_energy_difference, bands_weight)
 
-    # max distance
-    max_dist = np.sqrt(np.max(arr))
-    max_dist_loc = np.unravel_index(np.argmax(arr, axis=None), arr.shape)
-    # print(np.shape(arr), max_distance_loc)
 
-    arr_2 = np.abs(bands_energy_difference) * bands_weight
-    # max abs difference
-    max_dist_2 = np.max(arr_2)
-    max_dist_2_loc = np.unravel_index(np.argmax(arr_2, axis=None), arr_2.shape)
+def bands_distance_fermi_dirac(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    bands_dft: ty.Union[orm.BandsData, np.array],
+    bands_wannier: ty.Union[orm.BandsData, np.array],
+    mu: float,
+    sigma: float,
+    exclude_list_dft: list = None,
+    lower_cutoff: float = None,
+) -> float:
+    """Calculate the Fermi-Dirac-weighted RMS bands distance, in eV.
 
-    return (bands_dist, max_dist, max_dist_2, max_dist_loc, max_dist_2_loc)
+    Unlike :func:`bands_distance`, which scans ``mu`` from the Fermi energy to
+    the Fermi energy plus 5 eV at a fixed ``sigma`` of 0.1 eV and returns one
+    row per ``mu``, this returns a single number for the ``mu`` and ``sigma``
+    asked for.
+
+    :param bands_dft: bands computed by the DFT code, in eV.
+    :param bands_wannier: Wannier-interpolated bands, in eV.
+    :param mu: center of the Fermi-Dirac weight, in eV.
+    :param sigma: broadening of the Fermi-Dirac weight, in eV. The weight falls
+       from 1 to 0 over a few ``sigma`` around ``mu``, so a small value counts
+       the occupied bands only and a large one approaches
+       :func:`bands_distance_unweighted`.
+    :param exclude_list_dft: if passed should be a list of the excluded bands,
+       1-indexed
+    :param lower_cutoff: bands below this energy, in eV, are dropped from the
+       comparison. Defaults to None, meaning keep every band.
+    """
+    res = bands_distance_raw(
+        dft_bands=as_bands_array(bands_dft),
+        wannier_bands=as_bands_array(bands_wannier),
+        mu=mu,
+        sigma=sigma,
+        exclude_list_dft=exclude_list_dft,
+        lower_cutoff=lower_cutoff,
+    )
+    return float(res[0])
+
+
+def bands_distance_unweighted(
+    bands_dft: ty.Union[orm.BandsData, np.array],
+    bands_wannier: ty.Union[orm.BandsData, np.array],
+    exclude_list_dft: list = None,
+    lower_cutoff: float = None,
+) -> float:
+    """Calculate the RMS bands distance with every band weighted equally, in eV.
+
+    This is the ``sigma`` to infinity limit of :func:`bands_distance_fermi_dirac`:
+    the empty bands count as much as the occupied ones.
+
+    :param bands_dft: bands computed by the DFT code, in eV.
+    :param bands_wannier: Wannier-interpolated bands, in eV.
+    :param exclude_list_dft: if passed should be a list of the excluded bands,
+       1-indexed
+    :param lower_cutoff: bands below this energy, in eV, are dropped from the
+       comparison. Defaults to None, meaning keep every band.
+    """
+    res = bands_distance_isolated(
+        dft_bands=bands_dft,
+        wannier_bands=bands_wannier,
+        exclude_list_dft=exclude_list_dft,
+        lower_cutoff=lower_cutoff,
+    )
+    return float(res[0])

--- a/tests/utils/test_bands.py
+++ b/tests/utils/test_bands.py
@@ -83,3 +83,95 @@ def test_bands_distance(load_bands):
 
     atol = 1e-8
     assert np.allclose(dist, ref_dist, atol=atol)
+
+
+def test_bands_distance_fermi_dirac(load_bands):
+    """Test the function for ``bands_distance_fermi_dirac``."""
+    from aiida_wannier90_workflows.utils.bands.distance import (
+        bands_distance_fermi_dirac,
+    )
+
+    pw_bands = load_bands("W", "pw.json")
+    wan_bands = load_bands("W", "w90.json")
+
+    fermi_energy = 22.753
+    exclude_list_dft = [1, 2, 3, 4]
+
+    dist = bands_distance_fermi_dirac(
+        bands_dft=pw_bands,
+        bands_wannier=wan_bands,
+        mu=fermi_energy,
+        sigma=0.1,
+        exclude_list_dft=exclude_list_dft,
+        lower_cutoff=-30,
+    )
+
+    # The same weighting as the first row of ``bands_distance``
+    assert abs(dist - 1.036669313927612510e-02) < 1e-8
+
+
+def test_bands_distance_unweighted(load_bands):
+    """Test the function for ``bands_distance_unweighted``."""
+    import numpy as np
+
+    from aiida_wannier90_workflows.utils.bands.distance import (
+        bands_distance_fermi_dirac,
+        bands_distance_unweighted,
+    )
+
+    pw_bands = load_bands("W", "pw.json")
+    wan_bands = load_bands("W", "w90.json")
+
+    exclude_list_dft = [1, 2, 3, 4]
+
+    dist = bands_distance_unweighted(
+        bands_dft=pw_bands,
+        bands_wannier=wan_bands,
+        exclude_list_dft=exclude_list_dft,
+    )
+
+    # Every band weighted equally is a plain root-mean-square difference
+    num_bands = wan_bands.get_bands().shape[1]
+    difference = (
+        pw_bands.get_bands()[:, len(exclude_list_dft) :][:, :num_bands]
+        - wan_bands.get_bands()
+    )
+    assert abs(dist - np.sqrt(np.mean(difference**2))) < 1e-8
+
+    # ... and the limit of the Fermi-Dirac weighting for a broadening that
+    # reaches every band
+    dist_broad = bands_distance_fermi_dirac(
+        bands_dft=pw_bands,
+        bands_wannier=wan_bands,
+        mu=22.753,
+        sigma=1e8,
+        exclude_list_dft=exclude_list_dft,
+    )
+    assert abs(dist_broad - dist) < 1e-6
+
+
+def test_bands_distance_isolated_spin_collinear():
+    """Test ``bands_distance_isolated`` on spin-collinear bands.
+
+    Spin-collinear bands arrive as (num_spins, num_kpts, num_bands) and have to
+    be moved to (num_kpts, num_bands, num_spins) before the Wannier bands are
+    truncated to the DFT ones, otherwise the truncation slices the k-points.
+    """
+    import numpy as np
+
+    from aiida_wannier90_workflows.utils.bands.distance import bands_distance_isolated
+
+    num_spins, num_kpts, num_dft, num_wann = 2, 3, 5, 4
+
+    dft_bands = np.arange(num_spins * num_kpts * num_dft, dtype=float).reshape(
+        num_spins, num_kpts, num_dft
+    )
+    difference = 0.1 * np.arange(num_spins * num_kpts * num_wann, dtype=float).reshape(
+        num_spins, num_kpts, num_wann
+    )
+    wannier_bands = dft_bands[:, :, :num_wann] - difference
+
+    dist, _, max_dist_2, _, _ = bands_distance_isolated(dft_bands, wannier_bands)
+
+    assert abs(dist - np.sqrt(np.mean(difference**2))) < 1e-8
+    assert abs(max_dist_2 - difference.max()) < 1e-8


### PR DESCRIPTION
General tidying and refactoring of the bands distance code:

```python
from aiida_wannier90_workflows.utils.bands.distance import (
    bands_distance_fermi_dirac,
    bands_distance_unweighted,
)

# How well are the occupied bands reproduced?
bands_distance_fermi_dirac(pw_bands, wannier_bands, mu=fermi_energy, sigma=0.1)

# ... and how well is the whole manifold, empty bands included?
bands_distance_unweighted(pw_bands, wannier_bands)
```

## Problem

Previously, the only bands distance function gives back a table, not a number. `bands_distance` scanned `mu` from the Fermi energy to the Fermi energy plus 5 eV, in 1 eV steps, at a fixed `sigma` of 0.1 eV, and returns one row per `mu`. That is the right shape of answer for a report but the wrong one for anything that consumes a single figure of merit — comparing two disentanglement windows, driving an optimizer, asserting a tolerance in a test, etc. Callers currently reach past it to `bands_distance_raw` and index element 0 of a five-tuple, which is both obscure and the only way to choose your own `sigma`.

There is also no way to ask for a distance that treats the empty bands as seriously as the occupied ones. Every existing weighting is Fermi-Dirac or Gaussian around a `mu` near the Fermi level, so a Wannierisation that is excellent below the gap and poor above it scores well.

## Changes

- Add `bands_distance_fermi_dirac(bands_dft, bands_wannier, mu, sigma, ...)`, returning the weighted RMS distance in eV as a single float for the `mu` and `sigma` asked for.
- Add `bands_distance_unweighted(bands_dft, bands_wannier, ...)`, the `sigma` to infinity limit of the same expression, in which every band above `lower_cutoff` carries the same weight.
- Factor the two halves that every entry point repeats into helper functions
- **Behaviour change:** sharing `_align_bands` gives `bands_distance_isolated` the spin-collinear `moveaxis` that `bands_distance_raw` and `bands_distance` already had. Handed bands of shape (num_spins, num_kpts, num_bands), it used to treat the k-point axis as the band axis: it truncated along k-points, compared the wrong pairs, and raised `ValueError: operands could not be broadcast together` outright whenever the DFT and Wannier band counts differed. Spin-collinear callers of `bands_distance_isolated` (`Wannier90SplitWorkChain`) will now see different numbers

## Note

`black` reports `src/aiida_wannier90_workflows/workflows/wannier90.py` as needing reformatting on `main` already; this branch does not touch that file and does not fix it.
