### PR TITLE
Count the averaged channels of a fully relativistic pseudopotential

### DIFF
--- a/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
+++ b/src/aiida_wannier90_workflows/utils/pseudo/__init__.py
@@ -376,6 +376,13 @@ def get_number_of_projections(
     :type pseudos: dict
     :param spin_non_collinear: non-collinear or spin-orbit-coupling
     :type spin_non_collinear: bool
+    :param spin_orbit_coupling: whether the calculation has `lspinorb`, which
+        is the only case in which pw.x keeps the j = l +/- 1/2 channels of a
+        fully relativistic pseudo apart. `None` infers it from
+        `spin_non_collinear`, since `lspinorb` needs a non-collinear
+        calculation. Whether a pseudo is fully relativistic is read from the
+        pseudo itself, not from this flag.
+    :type spin_orbit_coupling: bool, optional
     :return: number of projections
     :rtype: int
     """
@@ -401,24 +408,31 @@ def get_number_of_projections(
             )
 
     if spin_orbit_coupling is None:
-        # I use the first pseudo to detect SOCs
-        kind = structure.get_kind_names()[0]
-        spin_orbit_coupling = is_soc_pseudo(get_upf_content(pseudos[kind]))
+        # `lspinorb` is only available to a non-collinear calculation
+        spin_orbit_coupling = spin_non_collinear
+
+    is_soc = {
+        kind: is_soc_pseudo(get_upf_content(upf)) for kind, upf in pseudos.items()
+    }
 
     tot_nprojs = 0
     for site in structure.sites:
         upf = pseudos[site.kind_name]
-        nprojs = get_number_of_projections_from_upf(upf)
-        if spin_non_collinear and not spin_orbit_coupling:
-            # For magnetic calculation with non-SOC pseudo, QE will generate
-            # 2 PSWFCs from each one PSWFC in the pseudo
-            # For collinear-magnetic calculation, spin up and down will calc
-            # seperately, so nprojs do not times 2
-            nprojs *= 2
-        elif not spin_non_collinear and spin_orbit_coupling:
-            # For non-magnetic calculation with SOC pseudo, QE will average
-            # the 2 PSWFCs into one
-            nprojs //= 2
+        if spin_orbit_coupling and is_soc[site.kind_name]:
+            # The j = l +/- 1/2 channels stay apart, each contributing 2j + 1
+            # spinor states, see q-e/upflib/upf_ions.f90:n_atom_wfc
+            nprojs = get_number_of_projections_from_upf(upf)
+        else:
+            # Without `lspinorb` pw.x averages the j = l +/- 1/2 channels of a
+            # fully relativistic pseudo back into one scalar-relativistic
+            # channel, see q-e/PW/src/average_pp.f90, so both kinds of pseudo
+            # contribute 2l + 1 states per shell
+            nprojs = get_number_of_projections_from_upf(upf, average_soc=True)
+            if spin_non_collinear:
+                # A non-collinear calculation makes two spinor states out of
+                # each of them. A collinear one calculates spin up and down
+                # separately, so nprojs is not doubled
+                nprojs *= 2
         tot_nprojs += nprojs
 
     return tot_nprojs

--- a/src/aiida_wannier90_workflows/utils/pseudo/upf.py
+++ b/src/aiida_wannier90_workflows/utils/pseudo/upf.py
@@ -428,7 +428,7 @@ def get_projections_from_upf(upf: orm.UpfData):
     return wannier_projections
 
 
-def parse_number_of_pswfc(upf_content: str) -> int:
+def parse_number_of_pswfc(upf_content: str, average_soc: bool = False) -> int:
     """Get the number of orbitals in the UPF file.
 
     This is also the number of orbitals used for projections in projwfc.x.
@@ -438,6 +438,13 @@ def parse_number_of_pswfc(upf_content: str) -> int:
 
     :param upf_content: the content of the UPF file
     :type upf_content: str
+    :param average_soc: for a fully relativistic pseudo, count the j = l - 1/2
+        and j = l + 1/2 channels of each shell as the single scalar-relativistic
+        channel they are averaged into, i.e. 2l + 1 states per shell. This is
+        what pw.x does whenever `lspinorb` is false, see
+        q-e/PW/src/average_pp.f90. Has no effect on a scalar-relativistic
+        pseudo.
+    :type average_soc: bool
     :return: number of PSWFC
     :rtype: int
     """
@@ -447,6 +454,17 @@ def parse_number_of_pswfc(upf_content: str) -> int:
         pswfc = parse_pswfc_nosoc(upf_content)
         for wfc in pswfc:
             l = wfc["l"]
+            num_projections += 2 * l + 1
+    elif average_soc:
+        pswfc = parse_pswfc_soc(upf_content)
+        # `average_pp` drops the j = l + 1/2 channel of every l > 0 shell and
+        # replaces the j = l - 1/2 one by the average of the pair; the l = 0
+        # channels, whose only j is 1/2, are kept as they are.
+        for wfc in pswfc:
+            l = wfc["l"]
+            j = wfc["j"]
+            if l != 0 and abs(j - l - 0.5) < 1e-6:
+                continue
             num_projections += 2 * l + 1
     else:
         pswfc = parse_pswfc_soc(upf_content)
@@ -463,13 +481,18 @@ def parse_number_of_pswfc(upf_content: str) -> int:
     return num_projections
 
 
-def get_number_of_projections_from_upf(upf: orm.UpfData) -> int:
+def get_number_of_projections_from_upf(
+    upf: orm.UpfData, average_soc: bool = False
+) -> int:
     """Aiida wrapper for `parse_number_of_pswfc`.
 
     :param upf: the UPF file
     :type upf: aiida.orm.UpfData
+    :param average_soc: count the averaged scalar-relativistic channels of a
+        fully relativistic pseudo, see `parse_number_of_pswfc`
+    :type average_soc: bool
     :return: number of projections in the UPF file
     :rtype: int
     """
     upf_content = get_upf_content(upf)
-    return parse_number_of_pswfc(upf_content)
+    return parse_number_of_pswfc(upf_content, average_soc=average_soc)

--- a/tests/utils/test_pseudo_projections.py
+++ b/tests/utils/test_pseudo_projections.py
@@ -1,0 +1,105 @@
+"""Tests for the projector counting in :py:mod:`~aiida_wannier90_workflows.utils.pseudo`."""
+
+import pytest
+
+from aiida_wannier90_workflows.utils.pseudo import (
+    get_number_of_projections,
+    get_pseudo_and_cutoff,
+)
+
+# The bundled fixtures carry silicon in both families, so the same structure can
+# be counted with a scalar- and a fully relativistic pseudopotential.
+SCALAR_RELATIVISTIC_FAMILY = "SSSP/1.3/PBEsol/efficiency"
+FULLY_RELATIVISTIC_FAMILY = "PseudoDojo/0.4/PBE/FR/standard/upf"
+
+
+@pytest.mark.parametrize(
+    ("spin_non_collinear", "spin_orbit_coupling", "expected"),
+    (
+        # Averaged 3S + 3P per atom: (2*0+1) + (2*1+1) = 4.
+        (False, False, 8),
+        # Non-collinear without spin-orbit: two spinors per averaged channel.
+        (True, False, 16),
+        # lspinorb: the j channels stay split, 2 + 4 + 2 = 8 per atom.
+        (True, True, 16),
+        # No regime given: infer it from `spin_non_collinear`.
+        (False, None, 8),
+        (True, None, 16),
+    ),
+)
+def test_number_of_projections_fully_relativistic(
+    generate_structure, spin_non_collinear, spin_orbit_coupling, expected
+):
+    """Count the projectors of a fully relativistic pseudo in each spin regime."""
+    structure = generate_structure("Si")
+    pseudos, _, _ = get_pseudo_and_cutoff(FULLY_RELATIVISTIC_FAMILY, structure)
+
+    assert (
+        get_number_of_projections(
+            structure, pseudos, spin_non_collinear, spin_orbit_coupling
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("spin_non_collinear", (False, True))
+def test_number_of_projections_relativity_agnostic(
+    generate_structure, spin_non_collinear
+):
+    """Outside a spin-orbit run an FR pseudo counts as its scalar counterpart.
+
+    pw.x averages the j = l +/- 1/2 pairs whenever ``lspinorb`` is false, so
+    the two families describe the same 3S and 3P channels of silicon.
+    """
+    structure = generate_structure("Si")
+    fully_relativistic, _, _ = get_pseudo_and_cutoff(
+        FULLY_RELATIVISTIC_FAMILY, structure
+    )
+    scalar_relativistic, _, _ = get_pseudo_and_cutoff(
+        SCALAR_RELATIVISTIC_FAMILY, structure
+    )
+
+    assert get_number_of_projections(
+        structure, fully_relativistic, spin_non_collinear, spin_orbit_coupling=False
+    ) == get_number_of_projections(
+        structure, scalar_relativistic, spin_non_collinear, spin_orbit_coupling=False
+    )
+
+
+@pytest.mark.parametrize("spin_non_collinear", (False, True))
+def test_number_of_projections_scalar_relativistic(
+    generate_structure, spin_non_collinear
+):
+    """A scalar-relativistic pseudo is unaffected by the spin-orbit flag."""
+    structure = generate_structure("Si")
+    pseudos, _, _ = get_pseudo_and_cutoff(SCALAR_RELATIVISTIC_FAMILY, structure)
+
+    expected = 16 if spin_non_collinear else 8
+    for spin_orbit_coupling in (False, True, None):
+        assert (
+            get_number_of_projections(
+                structure, pseudos, spin_non_collinear, spin_orbit_coupling
+            )
+            == expected
+        )
+
+
+def test_number_of_pswfc_averaged():
+    """``average_soc`` counts the channels QE's ``average_pp`` leaves behind."""
+    from aiida_wannier90_workflows.utils.pseudo.upf import parse_number_of_pswfc
+
+    # A 3S (j = 1/2) and a 3P split into j = 1/2 and j = 3/2, as PseudoDojo
+    # writes silicon in its fully relativistic set.
+    content = (
+        '<UPF version="2.0.1">\n'
+        '<PP_HEADER element="Si" z_valence="4.0" has_so="T" number_of_wfc="8"/>\n'
+        "<PP_SPIN_ORB>\n"
+        '<PP_RELWFC.1 index="1" lchi="0" jchi="0.5" nn="1"/>\n'
+        '<PP_RELWFC.2 index="2" lchi="1" jchi="1.5" nn="2"/>\n'
+        '<PP_RELWFC.3 index="3" lchi="1" jchi="0.5" nn="2"/>\n'
+        "</PP_SPIN_ORB>\n"
+        "</UPF>\n"
+    )
+
+    assert parse_number_of_pswfc(content) == 8
+    assert parse_number_of_pswfc(content, average_soc=True) == 4

--- a/tests/workflows/protocols/base/test_wannier90.py
+++ b/tests/workflows/protocols/base/test_wannier90.py
@@ -210,3 +210,35 @@ def test_metadata_overrides(
     )
 
     data_regression.check(serialize_builder(builder))
+
+
+def test_fully_relativistic_pseudos(fixture_code, generate_structure):
+    """Test ``Wannier90BaseWorkChain.get_builder_from_protocol`` with a fully relativistic family.
+
+    pw.x averages the j = l +/- 1/2 channels of such a pseudo unless the
+    calculation has `lspinorb`, so outside ``SpinType.SPIN_ORBIT`` the manifold
+    is the scalar-relativistic one.
+    """
+    code = fixture_code("wannier90.wannier90")
+    structure = generate_structure("Si")
+
+    def build(pseudo_family, spin_type):
+        builder = Wannier90BaseWorkChain.get_builder_from_protocol(
+            code,
+            structure=structure,
+            pseudo_family=pseudo_family,
+            spin_type=spin_type,
+        )
+        parameters = builder["wannier90"]["parameters"]
+        return parameters["num_wann"], parameters["num_bands"]
+
+    fully_relativistic = "PseudoDojo/0.4/PBE/FR/standard/upf"
+    scalar_relativistic = "SSSP/1.3/PBEsol/efficiency"
+
+    # Two silicon atoms, each with a 3S and a 3P channel.
+    assert build(fully_relativistic, SpinType.NONE) == (8, 16)
+    assert build(fully_relativistic, SpinType.NONE) == build(
+        scalar_relativistic, SpinType.NONE
+    )
+    # `lspinorb` keeps the channels apart, hence twice as many projections.
+    assert build(fully_relativistic, SpinType.SPIN_ORBIT) == (16, 32)


### PR DESCRIPTION
### Summary

Bulk silicon, `Wannier90BaseWorkChain.get_builder_from_protocol` at `SpinType.NONE`, with two families that describe the same 3S and 3P valence channels:

```
                                            num_wann   num_bands
SSSP/1.3/PBEsol/efficiency  (scalar rel.)          8          16
PseudoDojo/0.4/PBE/FR/standard/upf  before        16          32
PseudoDojo/0.4/PBE/FR/standard/upf  after          8          16
```

The fully relativistic file splits its 3P into j = 1/2 and j = 3/2, and pw.x averages that pair back into a single 3P for any calculation without `lspinorb` — so both families give pw.x the same eight atomic wave functions. With this PR, we now correctly count eight for both.

### Problem

`get_number_of_projections` decides whether a pseudopotential carries j-split channels from its `spin_orbit_coupling` argument, but the callers pass the *calculation regime* there: `get_builder_from_protocol` sets `spin_orbit_coupling = spin_type == SpinType.SPIN_ORBIT`, and `Wannier90WorkChain.sanity_check` reads `lspinorb` out of the pw.x parameters. A fully relativistic family run at any other spin type therefore keeps both j channels in the count, and every projector is counted twice.

The same conflation bites the other way: a scalar-relativistic pseudo passed with `spin_orbit_coupling=True` was counted as though it did carry j-split channels — halved for a collinear calculation (4 instead of 8 projectors for two silicon atoms) and left undoubled for a non-collinear one.

`num_wann` and `num_bands` inherit the error, while the amn that pw2wannier90 writes for `atom_proj` has `natomwfc` columns, i.e. the averaged count.

The use case is isolating the effect of spin-orbit coupling by running the non-SOC calculation off the same fully relativistic pseudopotential. QE supports this for norm-conserving pseudos and refuses it for ultrasoft and PAW ones, which cannot be averaged.

### Changes

The count now follows each pseudopotential's own `has_so` together with the calculation regime, rather than assuming one implies the other. Every site contributes the channels pw.x will actually build: the averaged, scalar-relativistic ones unless the calculation has `lspinorb`, doubled into spinors when it is non-collinear.

`parse_number_of_pswfc` and `get_number_of_projections_from_upf` take an `average_soc` keyword for the channels QE's `average_pp` leaves behind — 2l + 1 per shell, the j = l + 1/2 partner of every l > 0 shell dropped. Their default is unchanged, so an unqualified call still returns the raw per-j count.

`spin_orbit_coupling` keeps its meaning of "the calculation has `lspinorb`" and now says so in the docstring; `None` infers it from `spin_non_collinear`, since `lspinorb` is only available to a non-collinear calculation. For a scalar-relativistic pseudo every flag combination gives the count it gave before, apart from the halving above (reproduced over the four combinations on the silicon fixtures), so the change is confined to fully relativistic families.

**This changes numbers for anyone already running a fully relativistic family outside `SpinType.SPIN_ORBIT`**: `num_wann` and `num_bands` halve. Those are the runs that fail in wannier90 today, so no succeeding calculation should move, but existing provenance no longer matches what the code would now build.

Closes #96.