### PR TITLE
Stop the workchain when pw2wannier90 fails

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -1070,28 +1070,32 @@ class Wannier90WorkChain(
         """Verify that the Pw2wannier90BaseWorkChain for the pw2wannier90 run successfully finished."""
         if not self.ctx.spin_collinear:
             workchain = self.ctx.workchain_pw2wannier90
-            self.ctx.current_folder = workchain.outputs.remote_folder
             if not workchain.is_finished_ok:
                 self.report(
                     f"{workchain.process_label} failed with exit status {workchain.exit_status}"
                 )
+                return self.exit_codes.ERROR_SUB_PROCESS_FAILED_PW2WANNIER90
 
+            self.ctx.current_folder = workchain.outputs.remote_folder
         else:
             workchain = [
                 self.ctx.workchain_pw2wannier90_up,
                 self.ctx.workchain_pw2wannier90_down,
             ]
-            # current_folder for wannier90_up and _down will be defined seperately
-            self.ctx.current_folder_up, self.ctx.current_folder_down = (
-                self.ctx.workchain_pw2wannier90_up.outputs.remote_folder,
-                self.ctx.workchain_pw2wannier90_down.outputs.remote_folder,
-            )
             for workchain_spin in workchain:
                 if not workchain_spin.is_finished_ok:
                     self.report(
                         f"{workchain_spin.process_label} failed with exit status {workchain_spin.exit_status}"
                     )
                     return self.exit_codes.ERROR_SUB_PROCESS_FAILED_PW2WANNIER90
+
+            # current_folder for wannier90_up and _down will be defined seperately
+            self.ctx.current_folder_up = (
+                self.ctx.workchain_pw2wannier90_up.outputs.remote_folder
+            )
+            self.ctx.current_folder_down = (
+                self.ctx.workchain_pw2wannier90_down.outputs.remote_folder
+            )
 
     def prepare_wannier90_inputs(self):  # pylint: disable=too-many-statements
         """Prepare the inputs of wannier90 calculation before submission.

--- a/tests/workflows/test_wannier90.py
+++ b/tests/workflows/test_wannier90.py
@@ -3,6 +3,7 @@
 import io
 
 from plumpy.process_states import ProcessState
+import pytest
 
 from aiida import orm
 from aiida.common import LinkType
@@ -190,4 +191,41 @@ def test_scdm(
     assert all(
         _ in workchain.outputs
         for _ in ("scf", "nscf", "projwfc", "wannier90_pp", "pw2wannier90", "wannier90")
+    )
+
+
+@pytest.mark.parametrize("spin_collinear", (False, True))
+def test_inspect_pw2wannier90_failed(
+    generate_workchain_wannier90,
+    fixture_localhost,
+    generate_calc_job_node,
+    spin_collinear,
+):  # pylint: disable=redefined-outer-name
+    """Test that a failed pw2wannier90 run stops the workchain through its exit code.
+
+    A ``Pw2wannier90BaseWorkChain`` that did not finish successfully has no
+    ``remote_folder`` output, so reading it hides the real failure behind an
+    attribute error.
+    """
+
+    def generate_failed_workchain():
+        node = generate_calc_job_node("quantumespresso.pw2wannier90", fixture_localhost)
+        node.set_process_state(ProcessState.FINISHED)
+        node.set_exit_status(400)
+        assert "remote_folder" not in node.outputs
+        return node
+
+    workchain = generate_workchain_wannier90()
+    assert workchain.setup() is None
+    workchain.ctx.spin_collinear = spin_collinear
+
+    if spin_collinear:
+        workchain.ctx.workchain_pw2wannier90_up = generate_failed_workchain()
+        workchain.ctx.workchain_pw2wannier90_down = generate_failed_workchain()
+    else:
+        workchain.ctx.workchain_pw2wannier90 = generate_failed_workchain()
+
+    assert (
+        workchain.inspect_pw2wannier90()
+        == workchain.exit_codes.ERROR_SUB_PROCESS_FAILED_PW2WANNIER90
     )


### PR DESCRIPTION
# Problem

When pw2wannier90 fails inside `Wannier90WorkChain`, the user is told the wrong thing, and in the non-spin-collinear case the run does not stop. `inspect_pw2wannier90` reads `remote_folder` off the sub-workchain before testing `is_finished_ok`; a `Pw2wannier90BaseWorkChain` that did not finish successfully has no `remote_folder` output, so the read raises `NotExistent` and the parent workchain dies as `EXCEPTED` on a missing output. The pw2wannier90 error that actually stopped the calculation never reaches the report, and `ERROR_SUB_PROCESS_FAILED_PW2WANNIER90` is never returned.

The non-spin-collinear branch has a second fault: it reports the failure and falls through without returning the exit code, so once the ordering is corrected the step reports a failure and then hands back `None`, which the outline reads as success. The spin-collinear branch returns the exit code, so the two branches disagree about whether a missing set of overlap matrices is fatal.

This is issue #110, and it is the same ordering defect that #103 fixes in `inspect_wannier90` — applied here to a third and fourth place, plus the missing `return`.

# Changes

- Check `is_finished_ok` before touching `outputs.remote_folder`, in both branches, so the report names the sub-process exit status instead of the parent excepting on a missing output.
- Return `ERROR_SUB_PROCESS_FAILED_PW2WANNIER90` from the non-spin-collinear branch, matching what the spin-collinear branch already does. This is a behaviour change: a failed pw2wannier90 now aborts the workchain rather than continuing to the wannier90 step.

# Testing

- `test_inspect_pw2wannier90_failed`, parametrised over both spin branches, puts a failed sub-process with no `remote_folder` output into the context and asserts `inspect_pw2wannier90` returns `ERROR_SUB_PROCESS_FAILED_PW2WANNIER90`. On `main` both parametrisations fail with `NotExistent` raised from `KeyError: 'remote_folder'` — the read-before-check bug reproduced.
- Reordering alone does not satisfy the test: with the read moved after the check but no `return` added, the non-spin-collinear parametrisation fails on `assert None == ExitCode(status=460, ...)`. That is what distinguishes this from a cosmetic reordering, and it is the check that covers the missing exit code.
- Full suite green (163 tests), against aiida-quantumespresso 4.17 and aiida-core 2.9.

# Not fixed here

Three neighbouring faults turned up while checking whether the same mistakes live elsewhere; none is the fault fixed here, and each is reported separately rather than folded into this diff.

- `Wannier90SplitWorkChain.inspect_val` and `inspect_cond` read `outputs["interpolated_bands"]` before checking `is_finished_ok`, so they raise on a failed run for the same reason (code-read, not reproduced).
- `Wannier90OptimizeWorkChain.inspect_wannier90` calls `super().inspect_wannier90()` and discards its return value, so the parent's exit code would not stop the workchain. It cannot be tested until #103 lands, since the parent currently raises rather than returning (code-read).
- Two apparent typos in `optimize.py`: `self.ctx.collinear` where every other line says `spin_collinear` (`inspect_wannier90_optimize`, failure-report path), and `workchain[1].output.remote_folder` for `.outputs` (`inspect_wannier90_plot`, spin-collinear path). Both sit on paths the test suite does not reach (code-read).
