### PR TITLE
🚀 Release v3.0.0

### DIFF
--- a/src/aiida_wannier90_workflows/__init__.py
+++ b/src/aiida_wannier90_workflows/__init__.py
@@ -1,3 +1,3 @@
 """A set of advanced AiiDA Wannier90 Workchain."""
 
-__version__ = "2.8.0"
+__version__ = "3.0.0"


### PR DESCRIPTION
Supersedes the v2.8.0 tag, which numbered a breaking change as a minor release. Nothing was published to PyPI under it.

#95 changes what an overrides dict must look like: `inputpp` no longer merges with the protocol's `INPUTPP`, so an override written the only way that used to work is silently displaced. (Upstream shipped the same casing enforcement as aiida-quantumespresso 5.0.0)
