### PR TITLE
🐛 Preserve caller metadata on wannier90.x preprocessing/minimization

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/optimize.py
+++ b/src/aiida_wannier90_workflows/workflows/optimize.py
@@ -497,7 +497,7 @@ class Wannier90OptimizeWorkChain(
             if self.should_run_wannier90_plot():
                 inputs["wannier90"]["metadata"]["options"].pop("stash", None)
 
-            inputs["metadata"] = {"call_link_label": "wannier90"}
+            inputs.metadata.call_link_label = "wannier90"
             inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
             running = self.submit(Wannier90BaseWorkChain, **inputs)
             self.report(f"launching {running.process_label}<{running.pk}>")
@@ -517,7 +517,7 @@ class Wannier90OptimizeWorkChain(
         inputs = self.prepare_wannier90_inputs()
         if self.should_run_wannier90_plot():
             inputs["wannier90"]["metadata"]["options"].pop("stash", None)
-        inputs["metadata"] = {"call_link_label": "wannier90_up"}
+        inputs.metadata.call_link_label = "wannier90_up"
 
         inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
         running = self.submit(Wannier90BaseWorkChain, **inputs)
@@ -530,7 +530,7 @@ class Wannier90OptimizeWorkChain(
         inputs = self.prepare_wannier90_inputs()
         if self.should_run_wannier90_plot():
             inputs["wannier90"]["metadata"]["options"].pop("stash", None)
-        inputs["metadata"] = {"call_link_label": "wannier90_down"}
+        inputs.metadata.call_link_label = "wannier90_down"
 
         inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
         running = self.submit(Wannier90BaseWorkChain, **inputs)

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -148,32 +148,12 @@ class Wannier90WorkChain(
             namespace_options={
                 "required": False,
                 "populate_defaults": False,
-                # `Wannier90BaseWorkChain.spec().inputs.validator` is a mutable
-                # property `expose_inputs` would otherwise copy onto this
-                # namespace verbatim; it checks for the full input set
-                # (`wannier90`, `shift_energy_windows`, ...) this
-                # metadata-only namespace never carries, so it's cleared here.
+                # The source's validator expects inputs this metadata-only
+                # namespace never carries.
                 "validator": None,
-                # `absorb()` (plumpy's `PortNamespace.absorb`, which
-                # `expose_inputs` calls) copies mutable properties from the
-                # source namespace by iterating `dir(source)`, which is
-                # alphabetical. `Wannier90BaseWorkChain`'s own inputs
-                # namespace sets `valid_type = orm.Data` then `dynamic =
-                # False`, in that order, deliberately -- its own comment
-                # notes that setting `valid_type` forces `dynamic = True` as
-                # a side effect, so it resets `dynamic` afterwards. But
-                # "dynamic" sorts before "valid_type", so `absorb()` copies
-                # them in the wrong order for that protection to survive:
-                # copying `dynamic = False` first, then copying `valid_type
-                # = orm.Data` re-triggers the side effect, leaving this
-                # namespace dynamic regardless of an explicit override here
-                # (an override of `dynamic` alone is copied first, then
-                # overwritten the same way). Overriding `valid_type` to
-                # `None` instead survives, since `None` is the one value
-                # whose setter sets `dynamic = False` rather than `True`,
-                # and nothing later in the alphabetical copy touches it
-                # again -- this is the actual fix; `dynamic` needs no
-                # explicit override once `valid_type` is `None`.
+                # Must be None, not a `dynamic` override: the copied
+                # `valid_type` setter re-enables `dynamic` after any
+                # explicit `dynamic: False` has been applied.
                 "valid_type": None,
                 "help": (
                     "Metadata (e.g. `label`) for the `Wannier90BaseWorkChain` run in "
@@ -862,13 +842,8 @@ class Wannier90WorkChain(
             get_fermi_energy_from_nscf,
         )
 
-        # Physics inputs always come from `wannier90`, never `wannier90_pp`:
-        # the preprocessing and minimization runs are two phases of one
-        # calculation (the .nnkp preprocessing writes is what pw2wannier90
-        # and the minimization consume), so they can't diverge. `wannier90_pp`
-        # only ever carries `metadata` (e.g. a distinct `label`), swapped in
-        # here when a caller sets it; absent, the preprocessing run keeps
-        # `wannier90`'s own metadata, same as before this namespace existed.
+        # `wannier90_pp` carries metadata only; physics always reads the
+        # `wannier90` namespace.
         base_inputs = AttributeDict(
             self.exposed_inputs(Wannier90BaseWorkChain, namespace="wannier90")
         )

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -144,18 +144,48 @@ class Wannier90WorkChain(
         spec.expose_inputs(
             Wannier90BaseWorkChain,
             namespace="wannier90_pp",
-            exclude=("clean_workdir", "wannier90.structure"),
+            include=("metadata",),
             namespace_options={
                 "required": False,
                 "populate_defaults": False,
+                # `Wannier90BaseWorkChain.spec().inputs.validator` is a mutable
+                # property `expose_inputs` would otherwise copy onto this
+                # namespace verbatim; it checks for the full input set
+                # (`wannier90`, `shift_energy_windows`, ...) this
+                # metadata-only namespace never carries, so it's cleared here.
+                "validator": None,
+                # `absorb()` (plumpy's `PortNamespace.absorb`, which
+                # `expose_inputs` calls) copies mutable properties from the
+                # source namespace by iterating `dir(source)`, which is
+                # alphabetical. `Wannier90BaseWorkChain`'s own inputs
+                # namespace sets `valid_type = orm.Data` then `dynamic =
+                # False`, in that order, deliberately -- its own comment
+                # notes that setting `valid_type` forces `dynamic = True` as
+                # a side effect, so it resets `dynamic` afterwards. But
+                # "dynamic" sorts before "valid_type", so `absorb()` copies
+                # them in the wrong order for that protection to survive:
+                # copying `dynamic = False` first, then copying `valid_type
+                # = orm.Data` re-triggers the side effect, leaving this
+                # namespace dynamic regardless of an explicit override here
+                # (an override of `dynamic` alone is copied first, then
+                # overwritten the same way). Overriding `valid_type` to
+                # `None` instead survives, since `None` is the one value
+                # whose setter sets `dynamic = False` rather than `True`,
+                # and nothing later in the alphabetical copy touches it
+                # again -- this is the actual fix; `dynamic` needs no
+                # explicit override once `valid_type` is `None`.
+                "valid_type": None,
                 "help": (
-                    "Inputs for the `Wannier90BaseWorkChain` run in preprocessing mode. "
-                    "When omitted, the preprocessing run reuses the `wannier90` namespace, "
-                    "unchanged from before this namespace existed."
+                    "Metadata (e.g. `label`) for the `Wannier90BaseWorkChain` run in "
+                    "preprocessing mode, kept independent of `wannier90`'s so the two "
+                    "steps can be told apart. Physics inputs always come from "
+                    "`wannier90`: the preprocessing and minimization runs are two "
+                    "phases of one calculation (the .nnkp the minimization consumes "
+                    "must match what preprocessing wrote), so this namespace cannot "
+                    "carry its own code, parameters, or kpoints."
                 ),
             },
         )
-        spec.inputs["wannier90_pp"].validator = validate_inputs_base_wannier90
 
         spec.inputs.validator = validate_inputs
 
@@ -832,14 +862,18 @@ class Wannier90WorkChain(
             get_fermi_energy_from_nscf,
         )
 
-        # `wannier90_pp` is an optional namespace for callers who want the
-        # preprocessing run to carry its own inputs (e.g. a distinct
-        # `metadata.label`), independent of the minimization run built from
-        # `wannier90`. When absent, fall back to `wannier90` in full.
-        pp_namespace = "wannier90_pp" if "wannier90_pp" in self.inputs else "wannier90"
+        # Physics inputs always come from `wannier90`, never `wannier90_pp`:
+        # the preprocessing and minimization runs are two phases of one
+        # calculation (the .nnkp preprocessing writes is what pw2wannier90
+        # and the minimization consume), so they can't diverge. `wannier90_pp`
+        # only ever carries `metadata` (e.g. a distinct `label`), swapped in
+        # here when a caller sets it; absent, the preprocessing run keeps
+        # `wannier90`'s own metadata, same as before this namespace existed.
         base_inputs = AttributeDict(
-            self.exposed_inputs(Wannier90BaseWorkChain, namespace=pp_namespace)
+            self.exposed_inputs(Wannier90BaseWorkChain, namespace="wannier90")
         )
+        if "wannier90_pp" in self.inputs:
+            base_inputs["metadata"] = AttributeDict(self.inputs.wannier90_pp.metadata)
         inputs = base_inputs["wannier90"]
         inputs.structure = self.ctx.current_structure
         parameters = inputs.parameters.get_dict()

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -141,6 +141,21 @@ class Wannier90WorkChain(
             namespace_options={"help": "Inputs for the `Wannier90BaseWorkChain`."},
         )
         spec.inputs["wannier90"].validator = validate_inputs_base_wannier90
+        spec.expose_inputs(
+            Wannier90BaseWorkChain,
+            namespace="wannier90_pp",
+            exclude=("clean_workdir", "wannier90.structure"),
+            namespace_options={
+                "required": False,
+                "populate_defaults": False,
+                "help": (
+                    "Inputs for the `Wannier90BaseWorkChain` run in postproc mode. "
+                    "When omitted, the postproc run reuses the `wannier90` namespace, "
+                    "unchanged from before this namespace existed."
+                ),
+            },
+        )
+        spec.inputs["wannier90_pp"].validator = validate_inputs_base_wannier90
 
         spec.inputs.validator = validate_inputs
 
@@ -817,8 +832,13 @@ class Wannier90WorkChain(
             get_fermi_energy_from_nscf,
         )
 
+        # `wannier90_pp` is an optional namespace for callers who want the
+        # postproc run to carry its own inputs (e.g. a distinct
+        # `metadata.label`), independent of the minimization run built from
+        # `wannier90`. When absent, fall back to `wannier90` in full.
+        pp_namespace = "wannier90_pp" if "wannier90_pp" in self.inputs else "wannier90"
         base_inputs = AttributeDict(
-            self.exposed_inputs(Wannier90BaseWorkChain, namespace="wannier90")
+            self.exposed_inputs(Wannier90BaseWorkChain, namespace=pp_namespace)
         )
         inputs = base_inputs["wannier90"]
         inputs.structure = self.ctx.current_structure
@@ -890,7 +910,7 @@ class Wannier90WorkChain(
         """Wannier90 post processing step."""
         if not self.ctx.spin_collinear:
             inputs = self.prepare_wannier90_pp_inputs()
-            inputs["metadata"] = {"call_link_label": "wannier90_pp"}
+            inputs.metadata.call_link_label = "wannier90_pp"
 
             inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
             running = self.submit(Wannier90BaseWorkChain, **inputs)
@@ -911,7 +931,7 @@ class Wannier90WorkChain(
     def run_wannier90_pp_up(self):
         """Wannier90 post processing step for spin up."""
         inputs = self.prepare_wannier90_pp_inputs()
-        inputs["metadata"] = {"call_link_label": "wannier90_pp_up"}
+        inputs.metadata.call_link_label = "wannier90_pp_up"
 
         inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
         running = self.submit(Wannier90BaseWorkChain, **inputs)
@@ -922,7 +942,7 @@ class Wannier90WorkChain(
     def run_wannier90_pp_down(self):
         """Wannier90 post processing step for spin down."""
         inputs = self.prepare_wannier90_pp_inputs()
-        inputs["metadata"] = {"call_link_label": "wannier90_pp_down"}
+        inputs.metadata.call_link_label = "wannier90_pp_down"
 
         inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
         running = self.submit(Wannier90BaseWorkChain, **inputs)
@@ -1168,7 +1188,7 @@ class Wannier90WorkChain(
         """Wannier90 step for MLWF."""
         if not self.ctx.spin_collinear:
             inputs = self.prepare_wannier90_inputs()
-            inputs["metadata"] = {"call_link_label": "wannier90"}
+            inputs.metadata.call_link_label = "wannier90"
 
             inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
             running = self.submit(Wannier90BaseWorkChain, **inputs)
@@ -1188,7 +1208,7 @@ class Wannier90WorkChain(
     def run_wannier90_up(self):
         """Wannier90 step for MLWF."""
         inputs = self.prepare_wannier90_inputs()
-        inputs["metadata"] = {"call_link_label": "wannier90_up"}
+        inputs.metadata.call_link_label = "wannier90_up"
 
         inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
         running = self.submit(Wannier90BaseWorkChain, **inputs)
@@ -1199,7 +1219,7 @@ class Wannier90WorkChain(
     def run_wannier90_down(self):
         """Wannier90 step for MLWF."""
         inputs = self.prepare_wannier90_inputs()
-        inputs["metadata"] = {"call_link_label": "wannier90_down"}
+        inputs.metadata.call_link_label = "wannier90_down"
 
         inputs = prepare_process_inputs(Wannier90BaseWorkChain, inputs)
         running = self.submit(Wannier90BaseWorkChain, **inputs)

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -149,8 +149,8 @@ class Wannier90WorkChain(
                 "required": False,
                 "populate_defaults": False,
                 "help": (
-                    "Inputs for the `Wannier90BaseWorkChain` run in postproc mode. "
-                    "When omitted, the postproc run reuses the `wannier90` namespace, "
+                    "Inputs for the `Wannier90BaseWorkChain` run in preprocessing mode. "
+                    "When omitted, the preprocessing run reuses the `wannier90` namespace, "
                     "unchanged from before this namespace existed."
                 ),
             },
@@ -833,7 +833,7 @@ class Wannier90WorkChain(
         )
 
         # `wannier90_pp` is an optional namespace for callers who want the
-        # postproc run to carry its own inputs (e.g. a distinct
+        # preprocessing run to carry its own inputs (e.g. a distinct
         # `metadata.label`), independent of the minimization run built from
         # `wannier90`. When absent, fall back to `wannier90` in full.
         pp_namespace = "wannier90_pp" if "wannier90_pp" in self.inputs else "wannier90"

--- a/tests/workflows/test_optimize.py
+++ b/tests/workflows/test_optimize.py
@@ -1,0 +1,43 @@
+"""Tests for the `Wannier90OptimizeWorkChain` class."""
+
+from aiida import orm
+
+from .test_wannier90 import _run_through_wannier90_pp
+
+
+def test_metadata_survives_wannier90_override(
+    generate_workchain,
+    generate_inputs_wannier90,
+    fixture_localhost,
+    generate_remote_data,
+    generate_calc_job_node,
+):
+    """A caller-set ``wannier90.metadata`` label reaches the minimization node.
+
+    ``Wannier90OptimizeWorkChain`` overrides ``run_wannier90``/``_up``/
+    ``_down`` and used to reintroduce the same whole-``metadata``-dict
+    replacement bug fixed in the base ``Wannier90WorkChain`` -- this pins
+    the override too, reusing the base class's own mock chain since
+    ``prepare_wannier90_pp_inputs`` and ``run_wannier90_pp`` are inherited
+    unchanged.
+    """
+    inputs = generate_inputs_wannier90()
+    # Sidesteps `optimize.validate_inputs`'s `dis_proj_min`/`dis_proj_max`/
+    # `optimize_reference_bands` requirements, which are orthogonal to the
+    # metadata question this test pins.
+    inputs["optimize_disproj"] = orm.Bool(False)
+    inputs["wannier90"]["metadata"] = {
+        "label": "Minimization",
+        "description": "final MLWF run",
+    }
+
+    workchain = generate_workchain("wannier90_workflows.optimize", inputs)
+    _, captured = _run_through_wannier90_pp(
+        workchain, generate_remote_data, fixture_localhost, generate_calc_job_node
+    )
+
+    w90_workchain = workchain.run_wannier90()["workchain_wannier90"]
+
+    assert w90_workchain.label == "Minimization"
+    assert w90_workchain.description == "final MLWF run"
+    assert captured["wannier90"]["call_link_label"] == "wannier90"

--- a/tests/workflows/test_wannier90.py
+++ b/tests/workflows/test_wannier90.py
@@ -383,8 +383,13 @@ def test_wannier90_pp_namespace_absent_reuses_wannier90_inputs(
 
     Every existing caller never sets ``wannier90_pp``, so
     ``prepare_wannier90_pp_inputs`` must fall back to exactly the
-    ``wannier90`` namespace's own code/kpoints -- unchanged from before this
-    namespace existed.
+    ``wannier90`` namespace -- unchanged from before this namespace existed.
+    Compares everything ``prepare_wannier90_pp_inputs`` doesn't itself
+    rewrite (code, kpoints, parameters content, calcjob- and workchain-level
+    metadata); ``settings`` is excluded because that method always adds
+    ``postproc_setup`` regardless of which namespace it read from, so it
+    can never match the untouched ``wannier90`` inputs and isn't evidence
+    about the fallback either way.
     """
     inputs = generate_inputs_wannier90()
     inputs["wannier90"]["wannier90"]["parameters"] = orm.Dict({"fermi_energy": 6.0})
@@ -397,11 +402,13 @@ def test_wannier90_pp_namespace_absent_reuses_wannier90_inputs(
     direct_inputs = AttributeDict(
         workchain.exposed_inputs(Wannier90BaseWorkChain, namespace="wannier90")
     )
+    pp_calc, direct_calc = pp_inputs["wannier90"], direct_inputs["wannier90"]
 
-    assert (
-        pp_inputs["wannier90"]["code"].uuid == direct_inputs["wannier90"]["code"].uuid
-    )
-    assert (
-        pp_inputs["wannier90"]["kpoints"].uuid
-        == direct_inputs["wannier90"]["kpoints"].uuid
-    )
+    assert pp_calc["code"].uuid == direct_calc["code"].uuid
+    assert pp_calc["kpoints"].uuid == direct_calc["kpoints"].uuid
+    # `prepare_wannier90_pp_inputs` always re-derives `parameters` (it
+    # (re-)injects `fermi_energy`, here already present with the same
+    # value), so content rather than node identity is the fair comparison.
+    assert pp_calc["parameters"].get_dict() == direct_calc["parameters"].get_dict()
+    assert dict(pp_calc["metadata"]) == dict(direct_calc["metadata"])
+    assert dict(pp_inputs["metadata"]) == dict(direct_inputs["metadata"])

--- a/tests/workflows/test_wannier90.py
+++ b/tests/workflows/test_wannier90.py
@@ -3,12 +3,12 @@
 import io
 
 from plumpy.process_states import ProcessState
+import pytest
 
 from aiida import orm
 from aiida.common import AttributeDict, LinkType
 
 from aiida_quantumespresso.calculations.helpers import pw_input_helper
-from aiida_quantumespresso.utils.resources import get_default_options
 
 from aiida_wannier90_workflows.workflows.base.wannier90 import Wannier90BaseWorkChain
 
@@ -341,26 +341,19 @@ def test_wannier90_pp_namespace_gives_distinct_label(
     fixture_localhost,
     generate_remote_data,
     generate_calc_job_node,
-    fixture_code,
 ):
-    """A caller-set ``wannier90_pp`` namespace names the preprocessing node independently.
+    """A caller-set ``wannier90_pp.metadata`` names the preprocessing node independently.
 
-    ``wannier90_pp`` is optional; when a caller supplies it,
-    ``prepare_wannier90_pp_inputs`` builds entirely from it instead of
-    falling back to ``wannier90``, so the two wannier90.x steps can carry
-    distinct labels -- the point of adding the namespace.
+    ``wannier90_pp`` is optional and metadata-only; when a caller sets its
+    ``metadata``, ``prepare_wannier90_pp_inputs`` swaps that in for the
+    preprocessing run while still building every physics input off
+    ``wannier90`` -- see ``test_wannier90_pp_metadata_leaves_physics_unchanged``
+    for that half. Here: the two wannier90.x steps can carry distinct
+    labels, the point of adding the namespace.
     """
     inputs = generate_inputs_wannier90()
     inputs["wannier90"]["metadata"] = {"label": "Minimization"}
-    inputs["wannier90_pp"] = {
-        "wannier90": {
-            "code": fixture_code("wannier90.wannier90"),
-            "parameters": orm.Dict({"fermi_energy": 6.0}),
-            "kpoints": inputs["wannier90"]["wannier90"]["kpoints"],
-            "metadata": {"options": get_default_options()},
-        },
-        "metadata": {"label": "Preprocessing"},
-    }
+    inputs["wannier90_pp"] = {"metadata": {"label": "Preprocessing"}}
 
     workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
     assert "wannier90_pp" in workchain.inputs
@@ -376,27 +369,24 @@ def test_wannier90_pp_namespace_gives_distinct_label(
     assert captured["wannier90"]["call_link_label"] == "wannier90"
 
 
-def test_wannier90_pp_namespace_absent_reuses_wannier90_inputs(
+def test_wannier90_pp_metadata_leaves_physics_unchanged(
     generate_workchain, generate_inputs_wannier90
 ):
-    """With no ``wannier90_pp`` input, the preprocessing step still builds off ``wannier90`` alone.
+    """Setting ``wannier90_pp.metadata`` doesn't touch the preprocessing run's physics inputs.
 
-    Every existing caller never sets ``wannier90_pp``, so
-    ``prepare_wannier90_pp_inputs`` must fall back to exactly the
-    ``wannier90`` namespace -- unchanged from before this namespace existed.
-    Compares everything ``prepare_wannier90_pp_inputs`` doesn't itself
-    rewrite (code, kpoints, parameters content, calcjob- and workchain-level
-    metadata); ``settings`` is excluded because that method always adds
-    ``postproc_setup`` regardless of which namespace it read from, so it
-    can never match the untouched ``wannier90`` inputs and isn't evidence
-    about the fallback either way.
+    Physics inputs come from ``wannier90`` unconditionally now -- there's no
+    branch left that could read them from ``wannier90_pp`` (see
+    ``test_wannier90_pp_rejects_physics_inputs``, which pins that the spec
+    itself refuses to accept them there). This is the construction
+    guarantee that check exists for: even with ``wannier90_pp`` populated,
+    ``prepare_wannier90_pp_inputs``'s code/parameters still match
+    ``wannier90``'s directly.
     """
     inputs = generate_inputs_wannier90()
     inputs["wannier90"]["wannier90"]["parameters"] = orm.Dict({"fermi_energy": 6.0})
+    inputs["wannier90_pp"] = {"metadata": {"label": "Preprocessing"}}
 
     workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
-    assert "wannier90_pp" not in workchain.inputs
-
     assert workchain.setup() is None
     pp_inputs = workchain.prepare_wannier90_pp_inputs()
     direct_inputs = AttributeDict(
@@ -405,10 +395,42 @@ def test_wannier90_pp_namespace_absent_reuses_wannier90_inputs(
     pp_calc, direct_calc = pp_inputs["wannier90"], direct_inputs["wannier90"]
 
     assert pp_calc["code"].uuid == direct_calc["code"].uuid
-    assert pp_calc["kpoints"].uuid == direct_calc["kpoints"].uuid
     # `prepare_wannier90_pp_inputs` always re-derives `parameters` (it
     # (re-)injects `fermi_energy`, here already present with the same
     # value), so content rather than node identity is the fair comparison.
     assert pp_calc["parameters"].get_dict() == direct_calc["parameters"].get_dict()
-    assert dict(pp_calc["metadata"]) == dict(direct_calc["metadata"])
-    assert dict(pp_inputs["metadata"]) == dict(direct_inputs["metadata"])
+    assert pp_inputs["metadata"]["label"] == "Preprocessing"
+
+
+def test_wannier90_pp_rejects_physics_inputs(
+    generate_workchain, generate_inputs_wannier90, fixture_code
+):
+    """``wannier90_pp`` only accepts ``metadata`` -- physics inputs are rejected outright.
+
+    The pp and minimization runs are two phases of one calculation (the
+    ``.nnkp`` preprocessing writes is what pw2wannier90 and the
+    minimization consume), so divergent physics between them would be a
+    silent-wrong-results bug class. Making the spec itself refuse a
+    ``wannier90_pp.wannier90`` override -- rather than merely not reading
+    one -- is what makes that class of bug unrepresentable.
+
+    The override below is a *complete*, otherwise-valid
+    ``Wannier90BaseWorkChain`` input set (code, parameters, kpoints) --
+    before this namespace was restricted to metadata-only, the spec
+    accepted exactly this and built the preprocessing run from it,
+    silently, instead of ``wannier90``. An incomplete override (missing
+    `kpoints`, say) would raise a "required value was not provided" error
+    on both the old and new spec, which wouldn't discriminate between them.
+    """
+    inputs = generate_inputs_wannier90()
+    inputs["wannier90_pp"] = {
+        "metadata": {"label": "Preprocessing"},
+        "wannier90": {
+            "code": fixture_code("wannier90.wannier90"),
+            "parameters": orm.Dict({"fermi_energy": 99.0}),
+            "kpoints": inputs["wannier90"]["wannier90"]["kpoints"],
+        },
+    }
+
+    with pytest.raises(ValueError, match="Unexpected ports"):
+        generate_workchain("wannier90_workflows.wannier90", inputs)

--- a/tests/workflows/test_wannier90.py
+++ b/tests/workflows/test_wannier90.py
@@ -232,7 +232,7 @@ def _run_through_wannier90_pp(
     needs, without mocking the nscf/projwfc/pw2wannier90 steps this fix
     doesn't touch.
 
-    :return: the submitted postproc `Wannier90BaseWorkChain` node, and the
+    :return: the submitted preprocessing `Wannier90BaseWorkChain` node, and the
         dict from :func:`_install_submit_capture`.
     """
     captured = _install_submit_capture(workchain)
@@ -304,7 +304,7 @@ def test_metadata_survives_shared_wannier90_namespace(
 ):
     """A caller-set ``wannier90.metadata`` label reaches both wannier90.x steps.
 
-    Both the postproc (``wannier90_pp``) and minimization (``wannier90``)
+    Both the preprocessing (``wannier90_pp``) and minimization (``wannier90``)
     runs build from the one exposed ``wannier90`` namespace when no
     ``wannier90_pp`` override is given, so they carry the identical
     caller-set label. This pins the metadata-preservation fix, ambiguity
@@ -343,7 +343,7 @@ def test_wannier90_pp_namespace_gives_distinct_label(
     generate_calc_job_node,
     fixture_code,
 ):
-    """A caller-set ``wannier90_pp`` namespace names the postproc node independently.
+    """A caller-set ``wannier90_pp`` namespace names the preprocessing node independently.
 
     ``wannier90_pp`` is optional; when a caller supplies it,
     ``prepare_wannier90_pp_inputs`` builds entirely from it instead of
@@ -379,7 +379,7 @@ def test_wannier90_pp_namespace_gives_distinct_label(
 def test_wannier90_pp_namespace_absent_reuses_wannier90_inputs(
     generate_workchain, generate_inputs_wannier90
 ):
-    """With no ``wannier90_pp`` input, the postproc step still builds off ``wannier90`` alone.
+    """With no ``wannier90_pp`` input, the preprocessing step still builds off ``wannier90`` alone.
 
     Every existing caller never sets ``wannier90_pp``, so
     ``prepare_wannier90_pp_inputs`` must fall back to exactly the

--- a/tests/workflows/test_wannier90.py
+++ b/tests/workflows/test_wannier90.py
@@ -5,9 +5,12 @@ import io
 from plumpy.process_states import ProcessState
 
 from aiida import orm
-from aiida.common import LinkType
+from aiida.common import AttributeDict, LinkType
 
 from aiida_quantumespresso.calculations.helpers import pw_input_helper
+from aiida_quantumespresso.utils.resources import get_default_options
+
+from aiida_wannier90_workflows.workflows.base.wannier90 import Wannier90BaseWorkChain
 
 
 def test_scdm(
@@ -190,4 +193,215 @@ def test_scdm(
     assert all(
         _ in workchain.outputs
         for _ in ("scf", "nscf", "projwfc", "wannier90_pp", "pw2wannier90", "wannier90")
+    )
+
+
+def _install_submit_capture(workchain):
+    """Monkeypatch ``workchain.submit`` to also record each child's submitted metadata.
+
+    The synchronous ``instantiate_process`` test harness never registers
+    ``workchain`` on plumpy's process stack, so ``self.submit()`` never
+    creates the ``CALL_WORK`` link that would normally carry
+    ``call_link_label`` in the database -- there's nothing to inspect after
+    the fact. Capturing the raw ``metadata`` at the point of submission
+    tests the exact same code, keyed by the label so a caller can look up
+    what its call actually carried.
+
+    :return: a dict, populated as submissions happen, mapping each child's
+        ``call_link_label`` to its full submitted ``metadata`` dict.
+    """
+    captured = {}
+    original_submit = workchain.submit
+
+    def _submit(process_class, **kwargs):
+        metadata = dict(kwargs.get("metadata") or {})
+        captured[metadata.get("call_link_label")] = metadata
+        return original_submit(process_class, **kwargs)
+
+    workchain.submit = _submit
+    return captured
+
+
+def _run_through_wannier90_pp(
+    workchain, generate_remote_data, fixture_localhost, generate_calc_job_node
+):
+    """Mock the scf step and drive ``workchain`` through ``run_wannier90_pp``.
+
+    Sets ``ctx.workchain_wannier90_pp`` and ``ctx.current_folder`` so a
+    subsequent ``run_wannier90()`` call has what ``prepare_wannier90_inputs``
+    needs, without mocking the nscf/projwfc/pw2wannier90 steps this fix
+    doesn't touch.
+
+    :return: the submitted postproc `Wannier90BaseWorkChain` node, and the
+        dict from :func:`_install_submit_capture`.
+    """
+    captured = _install_submit_capture(workchain)
+    assert workchain.setup() is None
+
+    scf_workchain = workchain.run_scf()["workchain_scf"]
+    remote = generate_remote_data(
+        computer=fixture_localhost, remote_path="/path/on/remote"
+    )
+    remote.store()
+    remote.base.links.add_incoming(
+        scf_workchain, link_type=LinkType.RETURN, link_label="remote_folder"
+    )
+    params = orm.Dict({"fermi_energy": 6.0, "number_of_electrons": 8})
+    params.store()
+    params.base.links.add_incoming(
+        scf_workchain, link_type=LinkType.RETURN, link_label="output_parameters"
+    )
+    scf_workchain.set_process_state(ProcessState.FINISHED)
+    scf_workchain.set_exit_status(0)
+    workchain.ctx.workchain_scf = scf_workchain
+    pw_input_helper(
+        scf_workchain.inputs.pw.parameters.get_dict(), scf_workchain.inputs.pw.structure
+    )
+    assert workchain.inspect_scf() is None
+
+    w90pp_workchain = workchain.run_wannier90_pp()["workchain_wannier90_pp"]
+
+    entry_point_calc_job = "wannier90.wannier90"
+    calcjob = generate_calc_job_node(
+        entry_point_calc_job,
+        fixture_localhost,
+        inputs={"parameters": orm.Dict()},
+        store=False,
+    )
+    calcjob.set_process_state(ProcessState.FINISHED)
+    calcjob.set_exit_status(0)
+    calcjob.base.links.add_incoming(
+        workchain.inputs.structure,
+        link_type=LinkType.INPUT_CALC,
+        link_label="structure",
+    )
+    calcjob.base.links.add_incoming(
+        w90pp_workchain, link_type=LinkType.CALL_CALC, link_label="iteration_01"
+    )
+    calcjob.store()
+
+    nnkp_file = orm.SinglefileData(io.BytesIO(b"content"))
+    nnkp_file.store()
+    nnkp_file.base.links.add_incoming(
+        w90pp_workchain, link_type=LinkType.RETURN, link_label="nnkp_file"
+    )
+    w90pp_workchain.set_process_state(ProcessState.FINISHED)
+    w90pp_workchain.set_exit_status(0)
+    workchain.ctx.workchain_wannier90_pp = w90pp_workchain
+    assert workchain.inspect_wannier90_pp() is None
+
+    workchain.ctx.current_folder = remote
+
+    return w90pp_workchain, captured
+
+
+def test_metadata_survives_shared_wannier90_namespace(
+    generate_workchain,
+    generate_inputs_wannier90,
+    fixture_localhost,
+    generate_remote_data,
+    generate_calc_job_node,
+):
+    """A caller-set ``wannier90.metadata`` label reaches both wannier90.x steps.
+
+    Both the postproc (``wannier90_pp``) and minimization (``wannier90``)
+    runs build from the one exposed ``wannier90`` namespace when no
+    ``wannier90_pp`` override is given, so they carry the identical
+    caller-set label. This pins the metadata-preservation fix, ambiguity
+    and all -- it does not claim the two steps become distinguishable.
+    """
+    inputs = generate_inputs_wannier90()
+    inputs["wannier90"]["metadata"] = {
+        "label": "MLWF run",
+        "description": "shared label",
+    }
+
+    workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
+    w90pp_workchain, captured = _run_through_wannier90_pp(
+        workchain, generate_remote_data, fixture_localhost, generate_calc_job_node
+    )
+
+    # The stored node proves the label survived to persistence; the
+    # captured submission proves ``call_link_label`` still reads
+    # ``wannier90_pp`` (see ``_install_submit_capture`` for why this can't
+    # be read back off the node's incoming link in this test harness).
+    assert w90pp_workchain.label == "MLWF run"
+    assert w90pp_workchain.description == "shared label"
+    assert captured["wannier90_pp"]["call_link_label"] == "wannier90_pp"
+
+    w90_workchain = workchain.run_wannier90()["workchain_wannier90"]
+    assert w90_workchain.label == "MLWF run"
+    assert w90_workchain.description == "shared label"
+    assert captured["wannier90"]["call_link_label"] == "wannier90"
+
+
+def test_wannier90_pp_namespace_gives_distinct_label(
+    generate_workchain,
+    generate_inputs_wannier90,
+    fixture_localhost,
+    generate_remote_data,
+    generate_calc_job_node,
+    fixture_code,
+):
+    """A caller-set ``wannier90_pp`` namespace names the postproc node independently.
+
+    ``wannier90_pp`` is optional; when a caller supplies it,
+    ``prepare_wannier90_pp_inputs`` builds entirely from it instead of
+    falling back to ``wannier90``, so the two wannier90.x steps can carry
+    distinct labels -- the point of adding the namespace.
+    """
+    inputs = generate_inputs_wannier90()
+    inputs["wannier90"]["metadata"] = {"label": "Minimization"}
+    inputs["wannier90_pp"] = {
+        "wannier90": {
+            "code": fixture_code("wannier90.wannier90"),
+            "parameters": orm.Dict({"fermi_energy": 6.0}),
+            "kpoints": inputs["wannier90"]["wannier90"]["kpoints"],
+            "metadata": {"options": get_default_options()},
+        },
+        "metadata": {"label": "Preprocessing"},
+    }
+
+    workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
+    assert "wannier90_pp" in workchain.inputs
+
+    w90pp_workchain, captured = _run_through_wannier90_pp(
+        workchain, generate_remote_data, fixture_localhost, generate_calc_job_node
+    )
+    assert w90pp_workchain.label == "Preprocessing"
+    assert captured["wannier90_pp"]["call_link_label"] == "wannier90_pp"
+
+    w90_workchain = workchain.run_wannier90()["workchain_wannier90"]
+    assert w90_workchain.label == "Minimization"
+    assert captured["wannier90"]["call_link_label"] == "wannier90"
+
+
+def test_wannier90_pp_namespace_absent_reuses_wannier90_inputs(
+    generate_workchain, generate_inputs_wannier90
+):
+    """With no ``wannier90_pp`` input, the postproc step still builds off ``wannier90`` alone.
+
+    Every existing caller never sets ``wannier90_pp``, so
+    ``prepare_wannier90_pp_inputs`` must fall back to exactly the
+    ``wannier90`` namespace's own code/kpoints -- unchanged from before this
+    namespace existed.
+    """
+    inputs = generate_inputs_wannier90()
+    inputs["wannier90"]["wannier90"]["parameters"] = orm.Dict({"fermi_energy": 6.0})
+
+    workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
+    assert "wannier90_pp" not in workchain.inputs
+
+    assert workchain.setup() is None
+    pp_inputs = workchain.prepare_wannier90_pp_inputs()
+    direct_inputs = AttributeDict(
+        workchain.exposed_inputs(Wannier90BaseWorkChain, namespace="wannier90")
+    )
+
+    assert (
+        pp_inputs["wannier90"]["code"].uuid == direct_inputs["wannier90"]["code"].uuid
+    )
+    assert (
+        pp_inputs["wannier90"]["kpoints"].uuid
+        == direct_inputs["wannier90"]["kpoints"].uuid
     )


### PR DESCRIPTION
Before this PR:

```python
builder = Wannier90WorkChain.get_builder_from_protocol(...)
builder.wannier90.metadata.label = "MLWF run"
```

`verdi process list` shows a blank label for both the preprocessing and the minimization `Wannier90BaseWorkChain` node — the caller's label never reaches either one.

After this PR, both nodes show `MLWF run` (their `call_link_label`s are unaffected either way, staying `wannier90_pp` or `wannier90`). And with the new `wannier90_pp` metadata namespace populated:

```python
builder.wannier90_pp.metadata.label = "Preprocessing"
builder.wannier90.metadata.label = "Minimization"
```

`verdi process list` shows `Preprocessing` for the preprocessing node and `Minimization` for the minimization node -- the two runs off one namespace can finally be told apart. `wannier90_pp` carries `metadata` only: setting `builder.wannier90_pp.wannier90.parameters = ...` is rejected outright, because the preprocessing and minimization runs are two phases of one calculation (the `.nnkp` preprocessing writes is what pw2wannier90 and the minimization consume), so letting their physics inputs diverge would be a silent-wrong-results bug, not a convenience.

## Problem

`Wannier90WorkChain` submits its two wannier90.x steps (a preprocessing pass, then the minimization) by replacing the whole `metadata` dict with just `{"call_link_label": ...}`, discarding whatever `label`, `description`, or `options` a caller set. The workchain's other four steps (scf, nscf, projwfc, pw2wannier90) only ever update `call_link_label` in place, so their caller-set metadata survives -- these two didn't. `Wannier90OptimizeWorkChain` overrides the same two minimization methods (`run_wannier90`/`_up`/`_down`) and reintroduced the identical bug there.

Both steps also read from the same exposed `wannier90` namespace, so a bare mutate-not-replace fix alone would give the preprocessing node and the minimization node the identical label. There was no way for a caller to tell them apart, even once the metadata itself stopped being discarded.

## Changes

- All nine submission call sites that replaced the whole `metadata` dict now update `metadata.call_link_label` in place instead, matching the four sibling call sites (scf, nscf, projwfc, pw2wannier90) that already did: `Wannier90WorkChain.run_wannier90_pp`/`_up`/`_down`, `Wannier90WorkChain.run_wannier90`/`_up`/`_down`, and `Wannier90OptimizeWorkChain`'s override of the latter three.
- A new `wannier90_pp` input namespace on `Wannier90WorkChain` (inherited by every subclass) exposes only `metadata`, so a caller can give the preprocessing step its own label/description independent of `wannier90`'s -- and nothing else. `prepare_wannier90_pp_inputs` always builds the physics inputs (code, parameters, kpoints, structure) from `wannier90`; only the outer `metadata` dict is swapped in from `wannier90_pp` when a caller sets it. When absent (every existing caller), the preprocessing step's metadata is `wannier90`'s own, exactly as before this namespace existed.
- One aiida-core/plumpy mechanic worth flagging for review: `expose_inputs`'s `namespace_options` copies the source namespace's mutable properties (`validator`, `dynamic`, `valid_type`, ...) by iterating them alphabetically. `Wannier90BaseWorkChain`'s own inputs namespace sets `valid_type` then resets `dynamic = False` afterwards (its own comment notes `valid_type` forces `dynamic = True` as a side effect) -- but "dynamic" sorts before "valid_type", so a plain `namespace_options={"dynamic": False}` override gets silently re-flipped `True` by the later `valid_type` copy. Overriding `valid_type` to `None` instead is what survives (its setter is the one that sets `dynamic = False`, and nothing later in the alphabetical copy touches it again). Also cleared the inherited `validator`, which expects the full `Wannier90BaseWorkChain` input set this metadata-only namespace never carries.

Not included: `Wannier90OptimizeWorkChain.run_wannier90_plot`/`_up`/`_down` and `run_wannier90_optimize`/`_up`/`_down` (`optimize.py`) still replace the whole `metadata` dict the same way. They aren't overrides of anything the base class exposes today -- `wannier90_plot` and the disproj-optimization iterations are steps unique to this subclass -- so they're the same bug class but outside this PR's stated scope (preserving metadata on the shared preprocessing/minimization steps).