### PR TITLE
🐛 Derive collinear-spin detection from the parent folder's creator

### DIFF
--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -735,6 +735,33 @@ class Wannier90WorkChain(
         for note in notes:
             print(f"  * {note}")
 
+    @staticmethod
+    def _get_nspin_from_parent_folder(folder: orm.RemoteData) -> ty.Optional[int]:
+        """Return the ``nspin`` of the pw.x run that produced ``folder``.
+
+        Reads the stored ``SYSTEM`` parameters of the folder's creator
+        calculation, falling back to the parameters of the ``WorkChain`` that
+        called it (e.g. a ``PwBaseWorkChain`` wrapping the raw
+        ``PwCalculation``). Returns ``None`` if the folder has no creator, or
+        neither the creator nor its caller expose ``SYSTEM`` parameters (for
+        example an imported ``RemoteData`` or a non-pw creator).
+        """
+        creator = folder.creator
+        if creator is None:
+            return None
+
+        for node in (creator, creator.caller):
+            if node is None:
+                continue
+            for parameters in (
+                getattr(node.inputs, "parameters", None),
+                getattr(getattr(node.inputs, "pw", None), "parameters", None),
+            ):
+                if parameters is not None:
+                    return parameters.get_dict().get("SYSTEM", {}).get("nspin", 1)
+
+        return None
+
     def setup(self) -> None:
         """Define the current structure in the context to be the input structure."""
         self.ctx.current_structure = self.inputs.structure
@@ -759,12 +786,17 @@ class Wannier90WorkChain(
                     == 2
                 )
             else:
-                self.ctx.spin_collinear = False
-                self.report(
-                    "Warning: "
-                    "currently can not determine whether the workflow uses collinear spin, "
-                    "because it skips scf and nscf steps."
-                )
+                nspin = self._get_nspin_from_parent_folder(self.ctx.current_folder)
+                if nspin is None:
+                    self.ctx.spin_collinear = False
+                    self.report(
+                        "Warning: "
+                        "currently can not determine whether the workflow uses collinear spin, "
+                        "because it skips scf and nscf steps and the parent folder's creator "
+                        "does not expose SYSTEM parameters."
+                    )
+                else:
+                    self.ctx.spin_collinear = nspin == 2
         else:
             self.ctx.spin_collinear = (
                 self.inputs["scf"]["pw"]["parameters"]["SYSTEM"].get("nspin", 1) == 2

--- a/src/aiida_wannier90_workflows/workflows/wannier90.py
+++ b/src/aiida_wannier90_workflows/workflows/wannier90.py
@@ -744,7 +744,9 @@ class Wannier90WorkChain(
         called it (e.g. a ``PwBaseWorkChain`` wrapping the raw
         ``PwCalculation``). Returns ``None`` if the folder has no creator, or
         neither the creator nor its caller expose ``SYSTEM`` parameters (for
-        example an imported ``RemoteData`` or a non-pw creator).
+        example an imported ``RemoteData``). A non-pw creator whose parameters
+        carry no ``SYSTEM`` namelist (projwfc.x, pw2wannier90.x) reads as
+        ``nspin = 1`` rather than ``None``, so no warning is reported there.
         """
         creator = folder.creator
         if creator is None:

--- a/tests/workflows/test_wannier90.py
+++ b/tests/workflows/test_wannier90.py
@@ -229,3 +229,116 @@ def test_inspect_wannier90_failed(
         workchain.inspect_wannier90()
         == workchain.exit_codes.ERROR_SUB_PROCESS_FAILED_WANNIER90
     )
+
+
+def _spin_collinear_warnings(workchain):
+    """Return report logs about the undetermined-spin fallback, if any."""
+    return [
+        log
+        for log in orm.Log.collection.get_logs_for(workchain.node)
+        if "currently can not determine" in log.message
+    ]
+
+
+@pytest.mark.parametrize(("nspin", "expected_spin_collinear"), ((2, True), (1, False)))
+def test_setup_spin_collinear_projwfc_parent_folder(
+    generate_workchain,
+    generate_inputs_wannier90,
+    fixture_localhost,
+    generate_calc_job_node,
+    nspin,
+    expected_spin_collinear,
+):  # pylint: disable=redefined-outer-name
+    """When scf/nscf are skipped and `projwfc.parent_folder` is given, spin is read from its creator.
+
+    Regression test: before the fix, this path (and the `pw2wannier90.parent_folder`
+    path below) always set `spin_collinear = False` and reported a warning, silently
+    dropping the up/down step splitting for a collinear-spin caller.
+    """
+    creator = generate_calc_job_node(
+        "quantumespresso.pw",
+        fixture_localhost,
+        inputs={"parameters": orm.Dict({"SYSTEM": {"nspin": nspin}})},
+        store=True,
+    )
+    remote = orm.RemoteData(computer=fixture_localhost, remote_path="/path/on/remote")
+    remote.base.links.add_incoming(
+        creator, link_type=LinkType.CREATE, link_label="remote_folder"
+    )
+    remote.store()
+
+    inputs = generate_inputs_wannier90()
+    inputs.pop("scf")
+    inputs.pop("nscf")
+    inputs["projwfc"]["projwfc"]["parent_folder"] = remote
+    inputs["pw2wannier90"]["pw2wannier90"]["parent_folder"] = remote
+
+    workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
+    assert workchain.setup() is None
+
+    assert workchain.ctx.spin_collinear is expected_spin_collinear
+    assert not _spin_collinear_warnings(workchain)
+
+
+@pytest.mark.parametrize(("nspin", "expected_spin_collinear"), ((2, True), (1, False)))
+def test_setup_spin_collinear_pw2wannier90_parent_folder(
+    generate_workchain,
+    generate_inputs_wannier90,
+    fixture_localhost,
+    generate_calc_job_node,
+    nspin,
+    expected_spin_collinear,
+):  # pylint: disable=redefined-outer-name
+    """When scf/nscf/projwfc are all skipped, spin is read from `pw2wannier90.parent_folder`'s creator."""
+    creator = generate_calc_job_node(
+        "quantumespresso.pw",
+        fixture_localhost,
+        inputs={"parameters": orm.Dict({"SYSTEM": {"nspin": nspin}})},
+        store=True,
+    )
+    remote = orm.RemoteData(computer=fixture_localhost, remote_path="/path/on/remote")
+    remote.base.links.add_incoming(
+        creator, link_type=LinkType.CREATE, link_label="remote_folder"
+    )
+    remote.store()
+
+    inputs = generate_inputs_wannier90()
+    inputs.pop("scf")
+    inputs.pop("nscf")
+    inputs.pop("projwfc")
+    inputs["pw2wannier90"]["pw2wannier90"]["parent_folder"] = remote
+
+    workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
+    assert workchain.setup() is None
+
+    assert workchain.ctx.spin_collinear is expected_spin_collinear
+    assert not _spin_collinear_warnings(workchain)
+
+
+def test_setup_spin_collinear_unreachable_creator_falls_back(
+    generate_workchain,
+    generate_inputs_wannier90,
+    fixture_localhost,
+    generate_remote_data,
+):  # pylint: disable=redefined-outer-name
+    """A parent folder whose creator carries no SYSTEM parameters keeps the honest fallback.
+
+    Covers an imported `RemoteData` or a creator that isn't a pw.x calculation: the
+    workflow cannot know the spin treatment, so it must still default to
+    non-collinear and report the warning, rather than guessing.
+    """
+    remote = generate_remote_data(
+        fixture_localhost, "/path/on/remote", "quantumespresso.pw"
+    )
+
+    inputs = generate_inputs_wannier90()
+    inputs.pop("scf")
+    inputs.pop("nscf")
+    inputs["projwfc"]["projwfc"]["parent_folder"] = remote
+    inputs["pw2wannier90"]["pw2wannier90"]["parent_folder"] = remote
+
+    workchain = generate_workchain("wannier90_workflows.wannier90", inputs)
+    assert workchain.setup() is None
+
+    assert workchain.ctx.spin_collinear is False
+    assert _spin_collinear_warnings(workchain)


### PR DESCRIPTION
Before this PR:

```python
builder = Wannier90WorkChain.get_builder_from_protocol(
    ..., nscf_parent_folder=<a RemoteData from an nspin=2 nscf run>
)
```

Submitting this builder reports:

```
Warning: currently can not determine whether the workflow uses collinear spin, because it skips scf and nscf steps.
```

and silently runs the rest of the workflow as if it were non-collinear -- the up/down step splitting never happens, and a collinear-spin structure gets wrong results with only that one log line as a trace.

After this PR, the same call reports nothing, and the workflow correctly splits into up/down steps. If the parent folder's creator genuinely can't be inspected (e.g. an imported `RemoteData`), the fallback still applies, now with a more specific message: "... and the parent folder's creator does not expose SYSTEM parameters."

## Problem

`Wannier90WorkChain.setup()` has three branches that skip both scf and nscf (the parent-folder reuse paths): the caller gives `nscf` inputs directly, gives `projwfc.parent_folder`, or gives `pw2wannier90.parent_folder`.
- In the first branch, `setup()` reads `nspin` from the given `nscf` parameters and gets it right.
- In the other two, it set `spin_collinear = False` unconditionally and reported a warning -- even though `setup()` already resolves `current_folder.creator.caller` (the `PwBaseWorkChain` that produced the folder) two lines earlier, to populate `self.ctx.workchain_nscf`.

The information needed to determine the spin type was already reachable; the code just never looked at it.

## Changes

- New `Wannier90WorkChain._get_nspin_from_parent_folder` static helper reads `SYSTEM.nspin` from the parent folder's creator calculation's stored input parameters, falling back to the calling `PwBaseWorkChain`'s parameters (`inputs.pw.parameters`) when the creator doesn't expose `parameters` directly.
- The `projwfc.parent_folder` and `pw2wannier90.parent_folder` branches of `setup()` call this helper instead of hard-coding `False`.
- When neither the creator nor its caller expose any parameters (an imported `RemoteData`), the workflow still defaults to non-collinear and reports the warning -- now the narrow fallback for a genuinely undeterminable case, not the whole skip-scf-and-nscf path. One documented blind spot: a non-pw creator whose parameters carry no `SYSTEM` namelist (projwfc.x, pw2wannier90.x) reads as `nspin = 1` without a warning -- the same default as before this PR, just silent; the helper's docstring says so.
- The `nscf`-given branch is untouched: it already read `nspin` correctly and doesn't go through the new helper.
